### PR TITLE
Added common testing tools, starting to convert tests to use these

### DIFF
--- a/myuw/test/api/__init__.py
+++ b/myuw/test/api/__init__.py
@@ -1,5 +1,10 @@
+from unittest2 import skipIf
 from django.core.urlresolvers import reverse
 from django.contrib.auth.models import User
+from django.test.utils import override_settings
+from django.test import TestCase
+from django.test.client import Client
+from django.core.urlresolvers import reverse
 
 
 def missing_url(name):
@@ -10,6 +15,10 @@ def missing_url(name):
         return True
 
     return False
+
+
+def require_url(url):
+    return skipIf(missing_url(url), 'myuw urls not configured')
 
 
 def get_user(username):
@@ -23,3 +32,49 @@ def get_user(username):
 
 def get_user_pass(username):
     return 'pass'
+
+
+FDAO_SWS = 'restclients.dao_implementation.sws.File'
+Session = 'django.contrib.sessions.middleware.SessionMiddleware'
+Common = 'django.middleware.common.CommonMiddleware'
+CsrfView = 'django.middleware.csrf.CsrfViewMiddleware'
+Auth = 'django.contrib.auth.middleware.AuthenticationMiddleware'
+RemoteUser = 'django.contrib.auth.middleware.RemoteUserMiddleware'
+Message = 'django.contrib.messages.middleware.MessageMiddleware'
+XFrame = 'django.middleware.clickjacking.XFrameOptionsMiddleware'
+UserService = 'userservice.user.UserServiceMiddleware'
+AUTH_BACKEND = 'django.contrib.auth.backends.ModelBackend'
+
+
+standard_test_override = override_settings(
+    RESTCLIENTS_SWS_DAO_CLASS=FDAO_SWS,
+    MIDDLEWARE_CLASSES=(Session,
+                        Common,
+                        CsrfView,
+                        Auth,
+                        RemoteUser,
+                        Message,
+                        XFrame,
+                        UserService,),
+    AUTHENTICATION_BACKENDS=(AUTH_BACKEND,))
+
+
+@standard_test_override
+class MyuwApiTest(TestCase):
+
+    def setUp(self):
+        self.client = Client()
+
+    def set_user(self, user):
+        get_user(user)
+        self.client.login(username=user,
+                          password=get_user_pass(user))
+
+    def set_date(self, date):
+        session = self.client.session
+        session['myuw_override_date'] = date
+        session.save()
+
+    def get_response_by_reverse(self, url_reverse, *args, **kwargs):
+        url = reverse(url_reverse, *args, **kwargs)
+        return self.client.get(url)

--- a/myuw/test/api/books.py
+++ b/myuw/test/api/books.py
@@ -1,52 +1,22 @@
-from django.test import TestCase
-from django.test.client import Client
-from django.core.urlresolvers import reverse
-from unittest2 import skipIf
-from myuw.test.api import missing_url, get_user, get_user_pass
-from django.test.utils import override_settings
+from myuw.test.api import missing_url, MyuwApiTest, require_url
 import json
 
 
-FDAO_SWS = 'restclients.dao_implementation.sws.File'
-Session = 'django.contrib.sessions.middleware.SessionMiddleware'
-Common = 'django.middleware.common.CommonMiddleware'
-CsrfView = 'django.middleware.csrf.CsrfViewMiddleware'
-Auth = 'django.contrib.auth.middleware.AuthenticationMiddleware'
-RemoteUser = 'django.contrib.auth.middleware.RemoteUserMiddleware'
-Message = 'django.contrib.messages.middleware.MessageMiddleware'
-XFrame = 'django.middleware.clickjacking.XFrameOptionsMiddleware'
-UserService = 'userservice.user.UserServiceMiddleware'
-AUTH_BACKEND = 'django.contrib.auth.backends.ModelBackend'
 VERBACOMPARE_URL_PREFIX = 'http://uw-seattle.verbacompare.com'
 IMAGE_URL_PREFIX = 'www7.bookstore.washington.edu/MyUWImage.taf'
 
 
-@override_settings(RESTCLIENTS_SWS_DAO_CLASS=FDAO_SWS,
-                   MIDDLEWARE_CLASSES=(Session,
-                                       Common,
-                                       CsrfView,
-                                       Auth,
-                                       RemoteUser,
-                                       Message,
-                                       XFrame,
-                                       UserService,
-                                       ),
-                   AUTHENTICATION_BACKENDS=(AUTH_BACKEND,)
-                   )
-class TestApiBooks(TestCase):
-    def setUp(self):
-        self.client = Client()
+class TestApiBooks(MyuwApiTest):
+    '''Tests textbooks api'''
 
-    @skipIf(missing_url("myuw_home"), "myuw urls not configured")
+    @require_url('myuw_home')
     def test_javerage_books(self):
-        url = reverse("myuw_book_api",
-                      kwargs={'year': 2013,
-                              'quarter': 'spring',
-                              'summer_term': ''})
-        get_user('javerage')
-        self.client.login(username='javerage',
-                          password=get_user_pass('javerage'))
-        response = self.client.get(url)
+        self.set_user('javerage')
+        response = self.get_response_by_reverse(
+            'myuw_book_api',
+            kwargs={'year': 2013,
+                    'quarter': 'spring',
+                    'summer_term': ''})
         self.assertEquals(response.status_code, 200)
 
         data = json.loads(response.content)
@@ -54,14 +24,17 @@ class TestApiBooks(TestCase):
         self.assertEquals(data["verba_link"],
                           ("%s/m?section_id=AB12345&quarter=spring" %
                            VERBACOMPARE_URL_PREFIX))
+
+        self.assertGreaterEqual(len(data['18532']), 1)
+        book = data['18532'][0]
         self.assertEquals(
-            data["18532"][0]["cover_image_url"],
+            book["cover_image_url"],
             ("%s?isbn=9780878935970&key=46c9ef715edb2ec69517e2c8e6ec9c18" %
              IMAGE_URL_PREFIX))
-        self.assertEquals(len(data["18532"][0]["authors"]), 1)
-        self.assertEquals(data["18532"][0]["is_required"], True)
-        self.assertEquals(data["18532"][0]["price"], None)
-        self.assertEquals(data["18532"][0]["used_price"], None)
-        self.assertEquals(data["18532"][0]["isbn"], '9780878935970')
-        self.assertEquals(data["18532"][0]["notes"], 'required')
-        self.assertEquals(data["18532"][0]["price"], None)
+        self.assertEquals(len(book["authors"]), 1)
+        self.assertTrue(book["is_required"])
+        self.assertIsNone(book["price"])
+        self.assertIsNone(book["used_price"])
+        self.assertEquals(book["isbn"], '9780878935970')
+        self.assertEquals(book["notes"], 'required')
+        self.assertIsNone(book["price"])

--- a/myuw/test/api/category_links.py
+++ b/myuw/test/api/category_links.py
@@ -1,51 +1,18 @@
-from django.test import TestCase
-from django.test.client import Client
-from django.core.urlresolvers import reverse
-from unittest2 import skipIf
-from myuw.test.api import missing_url, get_user, get_user_pass
-from django.test.utils import override_settings
+from myuw.test.api import MyuwApiTest, require_url
 import json
 
 
-FDAO_SWS = 'restclients.dao_implementation.sws.File'
-Session = 'django.contrib.sessions.middleware.SessionMiddleware'
-Common = 'django.middleware.common.CommonMiddleware'
-CsrfView = 'django.middleware.csrf.CsrfViewMiddleware'
-Auth = 'django.contrib.auth.middleware.AuthenticationMiddleware'
-RemoteUser = 'django.contrib.auth.middleware.RemoteUserMiddleware'
-Message = 'django.contrib.messages.middleware.MessageMiddleware'
-XFrame = 'django.middleware.clickjacking.XFrameOptionsMiddleware'
-UserService = 'userservice.user.UserServiceMiddleware'
-AUTH_BACKEND = 'django.contrib.auth.backends.ModelBackend'
+@require_url('myuw_home')
+class TestLinks(MyuwApiTest):
 
-
-@override_settings(RESTCLIENTS_SWS_DAO_CLASS=FDAO_SWS,
-                   MIDDLEWARE_CLASSES=(Session,
-                                       Common,
-                                       CsrfView,
-                                       Auth,
-                                       RemoteUser,
-                                       Message,
-                                       XFrame,
-                                       UserService,
-                                       ),
-                   AUTHENTICATION_BACKENDS=(AUTH_BACKEND,)
-                   )
-class TestLinks(TestCase):
-    def setUp(self):
-        self.client = Client()
-
-    @skipIf(missing_url("myuw_home"), "myuw urls not configured")
     def test_academics_links(self):
-        url = reverse("myuw_links_api",
-                      kwargs={'category_id': 'academics'})
-        get_user('javerage')
-        self.client.login(username='javerage',
-                          password=get_user_pass('javerage'))
-        response = self.client.get(url)
+        self.set_user('javerage')
+        response = self.get_response_by_reverse(
+            'myuw_links_api',
+            kwargs={'category_id': 'academics'})
         self.assertEquals(response.status_code, 200)
 
         data = json.loads(response.content)
 
         self.assertEquals(data["link_data"][0]["subcategory"], "Registration")
-        self.assertTrue(len(data["link_data"][0]["links"]) > 1)
+        self.assertGreater(len(data["link_data"][0]["links"]), 1)


### PR DESCRIPTION
Adds MyuwApiTest class to myuw.test.api, allowing for removal of large amounts of boilerplate code from individual test files. This handles the settings override as well.
Also provides a require_url decorator to make requiring a URL more concise and require less imports.