### PR TITLE
Adding a test for poorly formed br tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,8 @@ script:
   - ls -l ./node_modules/.bin/_mocha
   - ls -l ./node_modules/mocha/bin/_mocha
   - pep8 myuw/ --exclude=migrations,myuw/south_migrations,myuw/static
+  # Find </br> tags
+  - grep -re '<\s*/\s*br\s*>' myuw/templates/ ; test $? -eq 1
   - jshint myuw/static/js/  --verbose
   - mocha myuw/static/js/test/ --recursive
   - istanbul cover --include-all-sources -x "**/vendor/**" -x "**/site-packages/**" ./node_modules/mocha/bin/_mocha -- -R spec myuw/static/js/test/


### PR DESCRIPTION
This looks finds &lt;/br&gt; , which is necessary because browsers will render it as a proper &lt;br&gt;, our template precompiler will strip it out - so formatting is different on production than on local builds.

Are there other tags like that which should be disallowed?