### PR TITLE
Fixes critical notice display on mobile.

### DIFF
--- a/myuw/static/css/boilerplate.less
+++ b/myuw/static/css/boilerplate.less
@@ -116,9 +116,9 @@ body { padding: 0; margin: 0; font-family: "Open Sans",Helvetica,Arial,Verdana,s
 }
 
 
-#app_notices {
+#app_notices { margin-left: -16px; margin-right: -16px; margin-bottom: 16px;
 
-    @media @desktop { margin-left: 0; margin-right: 0; margin-bottom: 16px; padding: 0 16px; }
+    @media @two-column { margin-left: 0; margin-right: 0; margin-bottom: 16px; padding: 0 16px; }
 
     .notice-header { margin-top: 0; }
 


### PR DESCRIPTION
Fixes notices overrides so that left/right margins are removed for mobile and then re-added for 2-column layout (tablet & desktop).