### PR TITLE
IE11 hotfixes

### DIFF
--- a/myuw/static/css/components.less
+++ b/myuw/static/css/components.less
@@ -5,7 +5,7 @@
 .myuw-modal {
     h3 {
     margin-bottom: 10px;
-    font-family: 'encode_sans_normalbold';
+    font-family: 'encode_sans_normalbold', sans-serif;
     font-size: 18px;
     color: #85754d;
     }
@@ -44,7 +44,9 @@
     @media @two-column { border-left: solid 1px #ddd; border-right: solid 1px #ddd; margin-left: 0; margin-right: 0; }
 
     /*** card title ***/
-    .myuw-card-title { font-family: 'encode_sans_normalbold'; font-size: 24px !important; color: @uw-metalic-gold; margin-top: 8px; }
+    .myuw-card-title { font-family: 'encode_sans_normalbold', sans-serif; font-weight: 600; font-size: 24px !important; color: @uw-metalic-gold; margin-top: 8px;
+        &.text-danger { color: #a94442; }
+    }
 
     /*** card section ***/
     .myuw-card-section { padding-top: 16px;

--- a/myuw/static/css/mobile.less
+++ b/myuw/static/css/mobile.less
@@ -1505,7 +1505,7 @@ label { font-weight: normal; }
 
         .card {
             h4 { font-family: 'encode_sans_normalbold', sans-serif; font-weight: 600; font-size: @font-header-small; color: @darktan; margin-bottom: 1em;
-				.meeting-type {float: right; font-size: 12px; font-family: 'Open Sans', sans-serif; text-transform: uppercase; padding:2px 4px 2px 4px;border: 1px solid #eee;}
+				.meeting-type {float: right; font-size: 12px; font-family: 'Open Sans', sans-serif; font-weight: normal; text-transform: uppercase; padding:2px 4px 2px 4px;border: 1px solid #eee;}
                 .shortTitle { font-family: 'Roboto', sans-serif; font-weight: 400; color: #444 !important; font-size: 16px !important; margin-top: 5px; }
                 .offterm-date { font-size: 14px; font-family:'Roboto', sans-serif; color: #444 !important; line-height: 1.5;  }
             }

--- a/myuw/static/css/typography.less
+++ b/myuw/static/css/typography.less
@@ -1,7 +1,7 @@
 @import (reference) "boilerplate.less";
 @import (reference) "mobile.less";
 
-@fontface-card-title: 'encode_sans_normalbold';
+@fontface-card-title: 'encode_sans_normalbold', sans-serif;
 @fontface-card-heading: 'Roboto', sans-serif;
 @fontface-body: 'Open Sans', sans-serif;
 

--- a/myuw/templates/handlebars/banner/notice.html
+++ b/myuw/templates/handlebars/banner/notice.html
@@ -2,15 +2,14 @@
 {% tplhandlebars "notice_banner" %}
 
     <div id="app_notices" class="myuw-card">
-        <div class="notice-header">
-            {{ #if notices}}
-                <h3 class="notice-header text-danger">Critical Notices</h3>
-            {{else}}
-                <h3 class="notice-header no-critical">Notices</h3>
-            {{/if}}
-        </div>
 
-        <div class="critical-notices-container">
+        {{ #if notices}}
+            <h3 class="myuw-card-title text-danger">Critical Notices</h3>
+        {{else}}
+            <h3 class="myuw-card-title">Notices</h3>
+        {{/if}}
+
+        <div class="critical-notices-container myuw-card-section">
                {{ #if notices }}
                <ul class="notice-content-list">
                    {{ #each notices }}


### PR DESCRIPTION
This adds the "sans-serif" attribute to other less files that were missed in the first pass. Also saw that Critical Notices was not properly using the new "myuw-card" style for headers and content sections - so a fix for those were added as well.