### PR TITLE
Add classroom information link to the course schedule panel template

### DIFF
--- a/myuw/templates/handlebars/card/schedule/course_sche_panel.html
+++ b/myuw/templates/handlebars/card/schedule/course_sche_panel.html
@@ -42,6 +42,7 @@
                     {{#if latitude}}
                         </a>
                     {{/if}}
+                    <a href="http://www.washington.edu/classroom/{{ building }}+{{ room }}" data-linklabel="{{ building }} {{ room }} - Room Info">(Info)</a>
                 </td>
             {{/if}}
         </tr>


### PR DESCRIPTION
Students, _like me_, at the University of Washington would love to become acquainted with the classroom's specifications before even setting foot inside the room. Having a convenient link from MyUW allows students to quickly view the classroom specs and become familiar with the classroom since day one. For example, left-hand students may use the link to view the classroom layout to see which seats are suitable for them. Those who are like me would like to see if the classroom is equipped with an Automated Panopto Recording system, as this feature gives me the assurance in case if I had to miss a lecture or two.
Although I am not too familiar with this project's setup (I'm a Flask person, not Django 🎉), I tried my best by editing the handlebar template to include the classroom URL. Please take a look, and you're more than welcome to push commits to my branch (I have checked the `Allow edits from maintainers` box) to improve the pull request.