### PR TITLE
Thatssad/mailman popup table

### DIFF
--- a/myuw/static/css/components.less
+++ b/myuw/static/css/components.less
@@ -3,8 +3,8 @@
 
 /*** modals ***/
 .myuw-modal {
-    h3 {
-    margin-bottom: 10px;
+    h3, .myuw-modal-title {
+    margin-bottom: 8px;
     font-family: 'encode_sans_normalbold', sans-serif;
     font-weight: 600;
     font-size: 18px;

--- a/myuw/static/css/components.less
+++ b/myuw/static/css/components.less
@@ -122,7 +122,7 @@
     }
 
     /*** card content table **/
-    .table {
+    .table-borderless {
         tr {
             td:first-child { padding-left: 0; }
         }

--- a/myuw/static/css/components.less
+++ b/myuw/static/css/components.less
@@ -103,11 +103,11 @@
         padding-left: 0;
         margin-bottom: 8px;
 
-        li {
+        > li {
             margin: 0 0 8px 0;
         }
 
-        li:last-of-type {
+        > li:last-of-type {
             margin: 0;
         }
     }

--- a/myuw/static/css/mobile.less
+++ b/myuw/static/css/mobile.less
@@ -2080,10 +2080,9 @@ label { font-weight: normal; margin-bottom: auto; }
 
 th.mailman-select-all { width: 1%; }
 label.mailman-select-all-label { font-size: 12px; }
+th.mailman-create-sectionname-column { width: 8em; }
 th.mailman-sections-column { width: 99%; }
-th.mailman-manage-column { }
-.mailman-secondary-section {  }
-td.mailman-manage-links { white-space: nowrap; }
+.mailman-create-success { margin: 1em 0 2em 0; }
 
 /*** Accounts page ***/
 

--- a/myuw/static/css/mobile.less
+++ b/myuw/static/css/mobile.less
@@ -164,7 +164,8 @@ body {
 	font-weight: bold;
 }
 
-label { font-weight: normal; }
+// Over-ride bootstrap
+label { font-weight: normal; margin-bottom: auto; }
 
 
 /*** header ***/
@@ -2077,6 +2078,12 @@ label { font-weight: normal; }
     margin-right: 1em;
 }
 
+th.mailman-select-all { width: 1%; }
+label.mailman-select-all-label { font-size: 12px; }
+th.mailman-sections-column { width: 99%; }
+th.mailman-manage-column { }
+.mailman-secondary-section {  }
+td.mailman-manage-links { white-space: nowrap; }
 
 /*** Accounts page ***/
 

--- a/myuw/static/css/typography.less
+++ b/myuw/static/css/typography.less
@@ -75,6 +75,9 @@ abbr[title] {
     font-size: @fontsize-small;
 }
 
+.myuw-label-disabled {
+    
+}
 
 /** Lists **/
 

--- a/myuw/templates/handlebars/card/instructor_schedule/future/course_sche_panel.html
+++ b/myuw/templates/handlebars/card/instructor_schedule/future/course_sche_panel.html
@@ -4,7 +4,7 @@
 <h5 class="scheduleHeading">
 MEETING TIME
 </h5>
-<table class="table table-condensed table-course-schedule">
+<table class="table table-borderless table-condensed table-course-schedule">
     <thead class="sr-only">
         <tr>
             <th>Day(s)</th>
@@ -61,7 +61,7 @@ FINAL EXAM WILL BE
   {{#if final_exam.no_exam_or_nontraditional}}
     No Exam or Non-Traditional
   {{else}}
-    <table class="table table-condensed table-course-schedule">
+    <table class="table table-borderless table-condensed table-course-schedule">
       <thead class="sr-only">
         <tr>
           <th>Day</th>

--- a/myuw/templates/handlebars/card/instructor_schedule/mailman/request_email_lists.html
+++ b/myuw/templates/handlebars/card/instructor_schedule/mailman/request_email_lists.html
@@ -1,13 +1,13 @@
 {% load templatetag_handlebars %}
 {% tplhandlebars "request_email_lists_tmpl" %}
 
-<div class="modal-dialog" role="document">
+<div class="myuw-modal modal-dialog" role="document">
     <div class="modal-content">
         <form role="form" id="request_emaillist_form" method="POST">{% csrf_token %}
             <div class="modal-header">
                 <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
 
-                <h4>Create Mailing List</h4>
+                <h2 class="myuw-modal-title">Create Mailing List</h2>
             </div>
 
 

--- a/myuw/templates/handlebars/card/instructor_schedule/mailman/request_email_lists.html
+++ b/myuw/templates/handlebars/card/instructor_schedule/mailman/request_email_lists.html
@@ -59,80 +59,86 @@
 
                         <fieldset>
 
-                            {{#if multi_sections_wo_list}}
-                                <div class="clearfix">
-                                    <div class="pull-left">
-                                        <h5 style="font-weight: bold;">Course Sections</h5>
-                                    </div>
-                                    <div class="pull-right">
-                                        <label for="select-all">Select all </label>
-                                        <input type="checkbox" title="select/unselect all checkboxes"
-                                               id="select_all" name="select-all"/>
-                                    </div>
-                                </div>
-                            {{/if}}
+                            <table class="table table-condensed table-hover">
 
-                                <ul id="multi_section_checkboxes" class="clearfix unstyled-list">
-                                    <li class="section_single clearfix">
+                                <thead>
+                                    <tr>
+                                        <th class="mailman-select-all">
+                                            {{#if multi_sections_wo_list}}
+                                            <input type="checkbox" title="select or unselect all checkboxes" id="select_all" name="select-all" />
+                                            {{/if}}
+                                        </th>
+                                        <th>
+                                            Section
+                                            {{#if multi_sections_wo_list}}<br />
+                                            <label for="select-all" class="mailman-select-all-label">Select all</label>
+                                            {{/if}}
+                                        </th>
+                                    </tr>
+                                </thead>
+
+                                <tbody>
+                                    <tr id="multi_section_checkboxes" class="section_single">
                                         {{#if section_list.list_exists}}
-                                            <div class="pull-left">
-                                                <label for="section_single_{{section_list.section_id}}">{{../course_abbr}} {{../course_number}} {{section_list.section_id}} <span>(List already exists)</span></label>
-                                            </div>
-                                            <div class="pull-right">
+                                            <td>
                                                 <input type="checkbox" disabled="true" id="section_single_{{section_list.section_id}}">
-                                            </div>
+                                            </td>
+                                            <td>
+                                                <label for="section_single_{{section_list.section_id}}">{{ course_abbr }} {{course_number}} {{section_list.section_id}} <span class="myuw-note">Primary section</span> <span>(List already exists)</span></label>
+                                            </td>
+
                                         {{ else }}
-                                            <div class="pull-left">
-                                                <label for="section_single_{{section_list.section_id}}"
-                                                       title="primary section">
-                                                    {{../course_abbr}} {{../course_number}} {{section_list.section_id}}
-                                                </label>
-                                            </div>
-                                            <div class="pull-right">
+                                            <td>
                                                 <input type="checkbox"
                                                        id="section_single_{{section_list.section_id}}"
                                                        name="section_single_{{section_list.section_id}}"
                                                        value="{{section_list.section_label}}"
                                                        title="select section {{section_list.section_id}}" />
-                                            </div>
+                                            </td>
+                                            <td>
+                                                <label for="section_single_{{section_list.section_id}}"
+                                                       title="primary section">
+                                                    {{ course_abbr }} {{course_number}} {{section_list.section_id}} <span class="myuw-note">Primary section</span>
+                                                </label>
+                                            </td>
                                         {{/if}}
-                                    </li>
+                                    </tr>
 
                                     {{#each secondary_section_lists}}
-                                        <li class="secondary_single clearfix">
+                                        <tr class="secondary_single">
                                             {{#if list_exists}}
-                                                <div class="pull-left">
-                                                    <label for="secondary_single_{{section_id}}">{{../../course_abbr}} {{../../course_number}} {{section_id}} <span>(List already exists)</label>
-                                                </div>
-                                                <div class="pull-right">
+                                                <td>
                                                     <input type="checkbox" disabled="true" id="secondary_single_{{section_id}}">
-                                                </div>
+                                                </td>
+                                                <td>
+                                                    <label for="secondary_single_{{section_id}}">{{../course_abbr}} {{../course_number}} {{section_id}} <span>(List already exists)</label>
+                                                </td>
                                             {{else}}
-                                                <div class="pull-left">
-                                                    <label for="secondary_single_{{section_id}}">
-                                                        {{../../course_abbr}} {{../../course_number}} {{section_id}}
-                                                    </label>
-                                                </div>
-                                                <div class="pull-right">
+                                                <td>
                                                     <input type="checkbox" id="secondary_single_{{section_id}}"
                                                            name="secondary_single_{{section_id}}"
                                                            value="{{section_label}}"
                                                            title="select section {{section_id}}" />
-                                                </div>
+                                                </td>
+                                                <td>
+                                                    <label for="secondary_single_{{section_id}}">
+                                                        {{../course_abbr}} {{../course_number}} {{section_id}}
+                                                    </label>
+                                                </td>
                                             {{/if}}
-                                        </li>
+                                        </tr>
                                     {{/each}}
-                                </ul>
+                                </tbody>
+                            </table>
                         </fieldset>
                     </div>
                             {{#unless has_lists }}
-                                <a class="mailman_simple_toggle"  style="display: none" href="#">Back  to Simple Edit</a>
+                                <a class="mailman_simple_toggle"  style="display: none" href="#">Back to Simple Edit</a>
                             {{/unless}}
 
 
                 {{/unless}}
             {{/if}}
-            </button>
 
 
             <div class="modal-footer">

--- a/myuw/templates/handlebars/card/instructor_schedule/mailman/request_email_lists.html
+++ b/myuw/templates/handlebars/card/instructor_schedule/mailman/request_email_lists.html
@@ -15,46 +15,50 @@
             <div class="modal-body">
 
             {{#if request_sent }}
-                <div class="">
-                    <h3>Request submitted</h3>
+                <div class="mailman-create-success">
+                    <div class="text-center">
+                        <strong class="text-success"><i class="fa fa-check" aria-hidden="true"></i> Request submitted</strong>
+                    </div>
                     {#} <p>Total email list requested: {{ total_lists_requested }}.</p> {#}
-                    <ul class="">
+                    <p>Please note:</p>
+                    <ul>
                         <li>An email confirmation will be sent to {{ netid }}@uw.edu</li>
                         <li>Mailing lists may take up to 24 hours to activate</li>
+                        <li>Learn more: <a href="https://itconnect.uw.edu/connect/email/resources/mailman/"
+                              rel="help" target="_blank">Mailman help documentation</a></li>
                     </ul>
-                    <p><a href="https://itconnect.uw.edu/connect/email/resources/mailman/"
-                          rel="help" target="_blank">Learn more about Mailman email list manager</a></p>
                 </div>
 
             {{else}}
                 {{#unless has_lists}}
                     <div class="mailman_simple_create">
                         {{#unless section_list.list_exists}}
-                            <div>{{ course_abbr }} {{course_number}} {{section_id}}</div>
-                            <div>{{ capitalizeString quarter }} {{ year }}</div>
-                            <ul class="">
-                                <li>Creates a single email list for this section: {{section_list.list_address}}@uw.edu</li>
-                                <li>Stays synced with the official class list</li>
+                            <p>
+                                <strong>Request a single email list for {{ course_abbr }} {{course_number}} {{section_id}}, {{ capitalizeString quarter }} {{ year }}.</strong>
+                                {{#unless no_secondary_section }}{{#unless has_lists}}
+                                <br/>
+                                <span class="small">Need more email lists for this class? <a class="mailman_advanced_toggle" href="#">Request multiple email lists.</a></span>
+                                {{/unless}}{{/unless}}
+                            </p>
+
+                            <ul>
+                                <li>Mailing list address: {{section_list.list_address}}@uw.edu</li>
+                                <li>Mailing list will stay synced with the official class list</li>
+                                <li>Learn more: <a href="https://itconnect.uw.edu/connect/email/resources/mailman/"
+                                      rel="help" target="_blank">Mailman help documentation</a></li>
                             </ul>
-                            <p><a href="https://itconnect.uw.edu/connect/email/resources/mailman/"
-                                  rel="help" target="_blank">Learn more about Mailman email list manager</a></p>
                             <input type="hidden" id="section_single_{{section_list.section_id}}"
                                    name="section_single_{{section_list.section_id}}" value="{{section_list.section_label}}"/>
                         {{/unless}}
                     </div>
                 {{/unless}}
-                {{#unless no_secondary_section }}
+
+                {{#unless no_secondary_section }} {# if there are secondary sections #}
                     {#Hide advanced view if no lists exist#}
-                    {{#if has_lists}}
-                        <div class="mailman_advanced_create">
-                    {{else}}
-                        <a class="mailman_advanced_toggle" href="#">Advanced Edit</a>
-                        <div class="mailman_advanced_create" style="display:none">
-                    {{/if}}
+
+                    <div class="mailman_advanced_create" {{#unless has_lists}}style="display:none"{{/unless}}>
                         <div>
-                            <p>Create multiple email lists, one for each section selected.</p>
-                            <p><a href="https://itconnect.uw.edu/connect/email/resources/mailman/"
-                              rel="help" target="_blank">Learn more about Mailman email list manager</a></p>
+                            <p><strong>Request multiple email lists, one for each section selected:</strong></p>
                        </div>
 
                         <fieldset>
@@ -68,12 +72,13 @@
                                             <input type="checkbox" title="select or unselect all checkboxes" id="select_all" name="select-all" />
                                             {{/if}}
                                         </th>
-                                        <th>
+                                        <th class="mailman-create-sectionname-column">
                                             Section
                                             {{#if multi_sections_wo_list}}<br />
-                                            <label for="select-all" class="mailman-select-all-label">Select all</label>
+                                            <label for="select_all" class="mailman-select-all-label">Select all</label>
                                             {{/if}}
                                         </th>
+                                        <th><span class="sr-only">Does section already have a mailing list?</span></th>
                                     </tr>
                                 </thead>
 
@@ -84,8 +89,9 @@
                                                 <input type="checkbox" disabled="true" id="section_single_{{section_list.section_id}}">
                                             </td>
                                             <td>
-                                                <label for="section_single_{{section_list.section_id}}">{{ course_abbr }} {{course_number}} {{section_list.section_id}} <span class="myuw-note">Primary section</span> <span>(List already exists)</span></label>
+                                                <label class="text-muted" for="section_single_{{section_list.section_id}}">{{ course_abbr }} {{course_number}} {{section_list.section_id}}</label>
                                             </td>
+                                            <td class="text-muted myuw-note">List already exists</td>
 
                                         {{ else }}
                                             <td>
@@ -98,9 +104,10 @@
                                             <td>
                                                 <label for="section_single_{{section_list.section_id}}"
                                                        title="primary section">
-                                                    {{ course_abbr }} {{course_number}} {{section_list.section_id}} <span class="myuw-note">Primary section</span>
+                                                    {{ course_abbr }} {{course_number}} {{section_list.section_id}}
                                                 </label>
                                             </td>
+                                            <td></td>
                                         {{/if}}
                                     </tr>
 
@@ -111,8 +118,9 @@
                                                     <input type="checkbox" disabled="true" id="secondary_single_{{section_id}}">
                                                 </td>
                                                 <td>
-                                                    <label for="secondary_single_{{section_id}}">{{../course_abbr}} {{../course_number}} {{section_id}} <span>(List already exists)</label>
+                                                    <label class="text-muted" for="secondary_single_{{section_id}}">{{../course_abbr}} {{../course_number}} {{section_id}}
                                                 </td>
+                                                <td class="text-muted myuw-note">List already exists</td>
                                             {{else}}
                                                 <td>
                                                     <input type="checkbox" id="secondary_single_{{section_id}}"
@@ -125,6 +133,7 @@
                                                         {{../course_abbr}} {{../course_number}} {{section_id}}
                                                     </label>
                                                 </td>
+                                                <td></td>
                                             {{/if}}
                                         </tr>
                                     {{/each}}
@@ -132,19 +141,22 @@
                             </table>
                         </fieldset>
                     </div>
-                            {{#unless has_lists }}
-                                <a class="mailman_simple_toggle"  style="display: none" href="#">Back to Simple Edit</a>
-                            {{/unless}}
+
+
+                   {{#unless has_lists }}
+                        <a class="mailman_simple_toggle"  style="display: none" href="#"><i class="fa fa-arrow-left" aria-hidden="true"></i> Back: request a single mailing list</a>
+                    {{/unless}}
 
 
                 {{/unless}}
             {{/if}}
 
+            </div>
 
             <div class="modal-footer">
-                <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+                <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
                 {{#unless request_sent }}
-                <button type="submit" class="btn btn-primary" form="request_emaillist_form" value="Create Mailing Lists">Create Mailing Lists</button>
+                <button type="submit" class="btn btn-primary" form="request_emaillist_form" value="Create Mailing Lists">Submit</button>
                 {{/unless}}
             </div>
         </form>

--- a/myuw/templates/handlebars/card/instructor_schedule/mailman/view_email_lists.html
+++ b/myuw/templates/handlebars/card/instructor_schedule/mailman/view_email_lists.html
@@ -1,12 +1,12 @@
 {% load templatetag_handlebars %}
 {% tplhandlebars "manage_email_lists_tmpl" %}
 
-<div class="modal-dialog view-email-lists" role="document">
+<div class="myuw-modal modal-dialog view-email-lists" role="document">
     <div class="modal-content">
         <div class="modal-header">
             <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
 
-            <h4>{{course_abbr}} {{course_number}} Mailing Lists</h4>
+            <h2 class="myuw-modal-title">{{course_abbr}} {{course_number}} Mailing Lists</h2>
         </div>
 
         <div class="modal-body">
@@ -18,6 +18,7 @@
             <br />
             {{/if}}
 
+            {{#unless is_primary}}
             <div class="clearfix">
                 <div class="pull-left">
                     <span>{{course_abbr}} {{course_number}} {{section_list.section_id}}</span>
@@ -25,27 +26,40 @@
                 {{ #if section_list.list_admin_url }}
                 <div class="pull-right">
                     <a href="mailto:{{section_list.list_address}}@uw.edu" class="list-address">{{section_list.list_address}}@uw.edu</a>
-                    <a href="{{section_list.list_admin_url}}" class="course_class_list" target="_blank">Manage</a>
+                    <a href="{{section_list.list_admin_url}}" target="_blank">Manage</a>
                 </div>
                 {{ else }}
                 <div class="pull-right">-</div>
                 {{ /if }}
             </div>
+            {{/unless}}
 
             {{#if is_primary}}
             <ul class="unstyled-list">
+
+                <li class="clearfix">
+                    <div class="pull-left">
+                        <strong>{{course_abbr}} {{course_number}} {{section_list.section_id}}</strong>
+                    </div>
+                    {{ #if section_list.list_admin_url }}
+                    <div class="pull-right">
+                        <a href="mailto:{{section_list.list_address}}@uw.edu" class="list-address">{{section_list.list_address}}@uw.edu</a>
+                        <a href="{{section_list.list_admin_url}}" target="_blank">Manage</a>
+                    </div>
+                    {{ else }}
+                    <div class="pull-right">-</div>
+                    {{ /if }}
+                </li>
+
                 {{#each secondary_section_lists}}
                 <li class="clearfix">
+                    <div class="pull-left">{{../../course_abbr}} {{../../course_number}} {{section_id}}</div>
                     {{#if list_exists}}
-                        <div class="pull-left">
-                            <span>{{../../course_abbr}} {{../../course_number}} {{section_id}}</span>
-                        </div>
                         <div class="pull-right">
                             <a href="mailto:{{list_address}}@uw.edu" class="list-address">{{list_address}}@uw.edu</a>
                             <a href="{{list_admin_url}}" target="_blank">Manage</a>
                         </div>
                     {{else}}
-                        <div class="pull-left">{{../../course_abbr}} {{../../course_number}} {{section_id}}</div>
                         <div class="pull-right">-</div>
                     {{/if}}
                 </li>

--- a/myuw/templates/handlebars/card/instructor_schedule/mailman/view_email_lists.html
+++ b/myuw/templates/handlebars/card/instructor_schedule/mailman/view_email_lists.html
@@ -20,19 +20,18 @@
             {{/if}}
 
             {{#unless is_primary}}
-            <div class="clearfix">
-                <div class="pull-left">
-                    <span>{{course_abbr}} {{course_number}} {{section_list.section_id}}</span>
-                </div>
                 {{ #if section_list.list_admin_url }}
-                <div class="pull-right">
-                    <a href="mailto:{{section_list.list_address}}@uw.edu" class="list-address">{{section_list.list_address}}@uw.edu</a>
-                    <a href="{{section_list.list_admin_url}}" target="_blank">Manage</a>
+                <div class="clearfix">
+                    <div class="pull-left">
+                        <span>{{course_abbr}} {{course_number}} {{section_list.section_id}}</span>
+                    </div>
+
+                    <div class="pull-right">
+                        <a href="mailto:{{section_list.list_address}}@uw.edu" class="list-address">{{section_list.list_address}}@uw.edu</a>
+                        <a href="{{section_list.list_admin_url}}" target="_blank">Manage</a>
+                    </div>
                 </div>
-                {{ else }}
-                <div class="pull-right">-</div>
                 {{ /if }}
-            </div>
             {{/unless}}
 
             {{#if is_primary}}
@@ -40,43 +39,42 @@
                 <thead>
                     <tr>
                         <th class="mailman-sections-column">Section</th>
-                        <th class="mailman-manage-column">Mailing List</th>
+                        <th class="mailman-address-column">Mailing List</th>
+                        <th class="mailman-manage-column"><span class="sr-only">Manage list in Mailman</span></th>
                     </tr>
                 </thead>
                 <tbody>
+                    {{ #if section_list.list_admin_url }}
                     <tr>
                         <td>
-                        {{course_abbr}} {{course_number}} {{section_list.section_id}} <span class="myuw-note">Primary section</span>
+                        {{course_abbr}} {{course_number}} {{section_list.section_id}}
                         </td>
                         <td>
-                        {{ #if section_list.list_admin_url }}
                             <a href="mailto:{{section_list.list_address}}@uw.edu" class="list-address">{{section_list.list_address}}@uw.edu</a>
-                            <a href="{{section_list.list_admin_url}}" target="_blank">Manage</a>
-                        {{ else }}
-                            -
-                            {{ /if }}
                         </td>
+                        <td><a href="{{section_list.list_admin_url}}" target="_blank">Manage</a></td>
                     </tr>
-
+                    {{ /if }}
 
                     {{#each secondary_section_lists}}
+                    {{#if list_exists}}
                     <tr>
                         <td>
                             <span class="mailman-secondary-section">{{../course_abbr}} {{../course_number}} {{section_id}}</span>
                         </td>
                         <td class="mailman-manage-links">
-                        {{#if list_exists}}
                             <a href="mailto:{{list_address}}@uw.edu" class="list-address">{{list_address}}@uw.edu</a>
-                            <a href="{{list_admin_url}}" target="_blank">Manage</a>
-                        {{else}}
-                            -
-                        {{/if}}
                         </td>
+                        <td><a href="{{list_admin_url}}" target="_blank">Manage</a></td>
                     </tr>
+                    {{/if}}
                     {{/each}}
                 </tbody>
             </table>
             {{/if}}
+
+            <p>Need help with mailing lists? <a href="https://itconnect.uw.edu/connect/email/resources/mailman/"
+                  rel="help" target="_blank">Mailman help documentation</a></p>
 
         </div>
         <div class="modal-footer">

--- a/myuw/templates/handlebars/card/instructor_schedule/mailman/view_email_lists.html
+++ b/myuw/templates/handlebars/card/instructor_schedule/mailman/view_email_lists.html
@@ -13,9 +13,10 @@
 
             {{#if total_course_wo_list}}
             <div class="clearfix">
-                <div class="pull-right"><span class="card-badge-value"><a href="#" id="switch_to_create_email_list" class="btn btn-default">Create mailing list</a></span></div>
+                <div class="pull-right">
+                    <a href="#" id="switch_to_create_email_list" class="btn btn-primary btn-default">Add Mailing Lists</a>
+                </div>
             </div>
-            <br />
             {{/if}}
 
             {{#unless is_primary}}
@@ -35,36 +36,46 @@
             {{/unless}}
 
             {{#if is_primary}}
-            <ul class="unstyled-list">
+            <table class="table table-condensed table-hover">
+                <thead>
+                    <tr>
+                        <th class="mailman-sections-column">Section</th>
+                        <th class="mailman-manage-column">Mailing List</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td>
+                        {{course_abbr}} {{course_number}} {{section_list.section_id}} <span class="myuw-note">Primary section</span>
+                        </td>
+                        <td>
+                        {{ #if section_list.list_admin_url }}
+                            <a href="mailto:{{section_list.list_address}}@uw.edu" class="list-address">{{section_list.list_address}}@uw.edu</a>
+                            <a href="{{section_list.list_admin_url}}" target="_blank">Manage</a>
+                        {{ else }}
+                            -
+                            {{ /if }}
+                        </td>
+                    </tr>
 
-                <li class="clearfix">
-                    <div class="pull-left">
-                        <strong>{{course_abbr}} {{course_number}} {{section_list.section_id}}</strong>
-                    </div>
-                    {{ #if section_list.list_admin_url }}
-                    <div class="pull-right">
-                        <a href="mailto:{{section_list.list_address}}@uw.edu" class="list-address">{{section_list.list_address}}@uw.edu</a>
-                        <a href="{{section_list.list_admin_url}}" target="_blank">Manage</a>
-                    </div>
-                    {{ else }}
-                    <div class="pull-right">-</div>
-                    {{ /if }}
-                </li>
 
-                {{#each secondary_section_lists}}
-                <li class="clearfix">
-                    <div class="pull-left">{{../../course_abbr}} {{../../course_number}} {{section_id}}</div>
-                    {{#if list_exists}}
-                        <div class="pull-right">
+                    {{#each secondary_section_lists}}
+                    <tr>
+                        <td>
+                            <span class="mailman-secondary-section">{{../course_abbr}} {{../course_number}} {{section_id}}</span>
+                        </td>
+                        <td class="mailman-manage-links">
+                        {{#if list_exists}}
                             <a href="mailto:{{list_address}}@uw.edu" class="list-address">{{list_address}}@uw.edu</a>
                             <a href="{{list_admin_url}}" target="_blank">Manage</a>
-                        </div>
-                    {{else}}
-                        <div class="pull-right">-</div>
-                    {{/if}}
-                </li>
-                {{/each}}
-            </ul>
+                        {{else}}
+                            -
+                        {{/if}}
+                        </td>
+                    </tr>
+                    {{/each}}
+                </tbody>
+            </table>
             {{/if}}
 
         </div>

--- a/myuw/templates/handlebars/card/registration/myplan_courses.html
+++ b/myuw/templates/handlebars/card/registration/myplan_courses.html
@@ -21,7 +21,7 @@
                             <li>
                             {{ #if registrations_available }}
                                 {{ curriculum_abbr }} {{ course_number }}
-                                <table class="reg-status-table table table-condensed borderless" style="border-width: 0;">
+                                <table class="reg-status-table table table-condensed table-borderless borderless" style="border-width: 0;">
                                     <thead class="sr-only">
                                         <tr>
                                             <td>Section</td>

--- a/myuw/templates/handlebars/card/schedule/course_sche_panel.html
+++ b/myuw/templates/handlebars/card/schedule/course_sche_panel.html
@@ -5,7 +5,7 @@
 {{ #if has_eval}}{{ucfirst meetings.0.type}}{{ /if }} Schedule
 </h5>
 
-<table class="table table-condensed table-course-schedule">
+<table class="table table-borderless table-condensed table-course-schedule">
     <thead class="sr-only">
         <tr>
             <th>Day(s)</th>


### PR DESCRIPTION
Reworks the mailman popups a bit. Places the lists into tables to help with formatting. Updates a lot of the language. 
Also refactors how our CSS overrides the bootstrap `.table` class. Redid all the minimal tables to use a new `.table-borderless` class instead of blanket overriding the `.table` class.