### PR TITLE
Fixes bug that has banners displaying on class list page.

### DIFF
--- a/myuw/templates/base.html
+++ b/myuw/templates/base.html
@@ -116,6 +116,7 @@
 
         <h1 class="sr-only">MyUW</h1>
 
+        {% block desktop_banner %}
         <!-- message banner (desktop only) -->
         <div class="myuw-banner-desktop" id="app_messages" role="complementary">
             <div class="message-banner">
@@ -134,6 +135,7 @@
            </div>
         </div>
         <!-- end message banner -->
+        {% endblock %}
 
         <div class="myuw-body">
             <div class="myuw-wrapper">
@@ -172,6 +174,7 @@
                 {% endblock %}
                 <!-- end app_navigation -->
 
+                {% block mobile_banner %}
                 <!-- message banner (mobile only) -->
                 <div class="myuw-banner-mobile" id="app_messages" role="complementary">
                     <div class="message-banner">
@@ -190,6 +193,7 @@
                    </div>
                 </div>
                 <!-- end message banner -->
+                {% endblock %}
 
                 <div class="myuw-content">
                     <!-- app_content -->

--- a/myuw/templates/teaching/photo_list.html
+++ b/myuw/templates/teaching/photo_list.html
@@ -9,6 +9,8 @@
 
 {% block header %}{% endblock %}
 {% block mobile_navigation %}{% endblock %}
+{% block mobile_banner %}{% endblock %}
+{% block desktop_banner %}{% endblock %}
 {% block app_navigation %}{% endblock %}
 
 {% block teaching_content %}


### PR DESCRIPTION
Noticed that the message banner was being displayed on the class list popup. This was fixed by putting the desktop and mobile banners in template blocks in "base.html". The "photo_list.html" template then overrides them to being empty (similar to the other template blocks).