### PR TITLE
adds if statement around '& Dining' to the Husky Account card title

### DIFF
--- a/myuw/templates/handlebars/card/hfs.html
+++ b/myuw/templates/handlebars/card/hfs.html
@@ -3,8 +3,8 @@
 
 <div class="card clearfix"  data-name="HFSCard" data-type="card">
 
-    <h3 aria-hidden="true">Husky Card &amp; Dining</h3>
-    <h3 class="sr-only">Husky Card account and Dining account</h3>
+    <h3 aria-hidden="true">Husky Card{{#if resident_dining}} &amp; Dining{{/if}}</h3>
+    <h3 class="sr-only">Husky Card accounts{{#if resident_dining}} and Dining account{{/if}}</h3>
 
     <div class="card-badge-container">
 	<ul class="card_list">


### PR DESCRIPTION
Minor change to Husky Card card to remove "Dining" from the card title, as appropriate.

Can test with:
jinter = only has employee husky card
javerage = has all 3 husky card accounts