### PR TITLE
Adds comma separator to majors list. Fixes MUWM-3881

### DIFF
--- a/myuw/templates/handlebars/teaching/photo_list.html
+++ b/myuw/templates/handlebars/teaching/photo_list.html
@@ -54,7 +54,7 @@
                                         <div class="pull-left" style="width:50%; min-width: 272px;">
                                         Student Number:&nbsp;&nbsp;{{ student_number }} <br />
                                         UW NetID:&nbsp;&nbsp;{{ netid }} <br />
-                                        Major:&nbsp;&nbsp;{{ #each majors }}{{ full_name }}{{ /each }}<br />
+                                        Major:&nbsp;&nbsp;{{ #each majors }}{{ full_name }}{{#unless @last}},&nbsp;{{/unless}}{{ /each }}<br />
                                         Class:&nbsp;&nbsp;{{ class }}
                                         </div>
                                         <div class="pull-left" style="width:50%; min-width: 272px;">


### PR DESCRIPTION
Adds comma separator for each item in the list. Uses the "unless" conditional to check for the last item in the list and excludes the comma for that item. Single majors should always get caught by the unless they will be the only (and last?) item. 

I couldn't find where in the mock data we can add additional majors... so i'm hoping this just works.