### PR TITLE
client side expects 404 for non-instructed term schedules

### DIFF
--- a/myuw/static/js/ws_data.js
+++ b/myuw/static/js/ws_data.js
@@ -184,7 +184,6 @@ WSData = {
             var grading_is_open = course_data.grading_period_is_open;
             var grading_is_closed = course_data.grading_period_is_past;
             var grading_open = moment(course_data.term.grading_period_open);
-            var grading_aterm_open = moment(course_data.term.aterm_grading_period_open);
             var grading_deadline = moment(course_data.term.grade_submission_deadline);
             var ref = moment();
             // search param supports testing
@@ -198,7 +197,6 @@ WSData = {
             }
 
             var grading_open_relative = grading_open.from(ref);
-            var grading_aterm_open_relative = grading_aterm_open.from(ref);
             var grading_deadline_relative = grading_deadline.from(ref);
             var grading_open_date;
             var grading_deadline_date;
@@ -245,7 +243,6 @@ WSData = {
                 section.deadline_in_24_hours = deadline_in_24_hours;
                 section.grading_period_open_date = grading_open_date;
                 section.grading_period_relative_open = grading_open_relative;
-                section.aterm_grading_period_relative_open = grading_aterm_open_relative;
                 section.grade_submission_deadline_date = grading_deadline_date;
                 section.grade_submission_relative_deadline = grading_deadline_relative;
 

--- a/myuw/test/api/instructor_schedule.py
+++ b/myuw/test/api/instructor_schedule.py
@@ -154,4 +154,4 @@ class TestInstructorSection(MyuwApiTest):
         get_request_with_user('staff', now_request)
         sche = get_current_quarter_instructor_schedule(now_request)
         resp = InstScheCurQuar().GET(now_request)
-        self.assertEquals(resp.status_code, 200)
+        self.assertEquals(resp.status_code, 404)

--- a/myuw/views/api/instructor_schedule.py
+++ b/myuw/views/api/instructor_schedule.py
@@ -1,6 +1,7 @@
 import json
 import traceback
-from myuw.views.error import handle_exception, not_instructor_error
+from myuw.views.error import (handle_exception, not_instructor_error,
+                              data_not_found)
 import logging
 from django.conf import settings
 from django.http import HttpResponse
@@ -47,9 +48,15 @@ class InstSche(RESTDispatch):
                 status 404: no schedule found (teaching no courses)
         """
         schedule = get_instructor_schedule_by_term(term)
-        resp_data = load_schedule(request, schedule)
+        if (len(schedule.sections) == 0 and
+                not hasattr(schedule, 'section_references')):
+            response = data_not_found()
+        else:
+            resp_data = load_schedule(request, schedule)
+            response = HttpResponse(json.dumps(resp_data))
+
         log_success_response(logger, timer)
-        return HttpResponse(json.dumps(resp_data))
+        return response
 
 
 def set_class_website_data(url):


### PR DESCRIPTION
which has the side effect of getting rid of the future term instructed course card when there are zero instructed sections for that term