### PR TITLE
removes conditionals showing quarter and year to the users with lots …

### DIFF
--- a/myuw/templates/handlebars/card/instructor_schedule/course_cards.html
+++ b/myuw/templates/handlebars/card/instructor_schedule/course_cards.html
@@ -63,7 +63,7 @@
                 <li>
                     <div data-name="CourseCard" data-type="card" data-identifier="{{ curriculum_abbr }} {{course_number}} {{section_id}}">
                         <div id="course_wrapper{{index}}">
-                            <a href="/teaching/{{term.year}},{{term.quarter}},{{curriculum_abbr}},{{course_number}}/{{section_id}}"><span class="courseIDtitle">{{ curriculum_abbr }} {{course_number}} {{section_id}}</span></a>{{#if ../future_term}} ({{capitalizeString ../../quarter}} {{../../year}}){{/if}}{{#if ../past_term}} ({{capitalizeString ../../quarter}} {{../../year}}){{/if}}
+                            <a href="/teaching/{{term.year}},{{term.quarter}},{{curriculum_abbr}},{{course_number}}/{{section_id}}"><span class="courseIDtitle">{{ curriculum_abbr }} {{course_number}} {{section_id}}</span></a>
                         </div>
                     </div>
                 </li>


### PR DESCRIPTION
…of courses taught.

Since the quarter and year are displayed in the tabs above, I don't think we need it on each course name.

Fix for Bug MUWM-3890
https://jira.cac.washington.edu/browse/MUWM-3890