### PR TITLE
spaces in hrefs to preserve minified quoting

### DIFF
--- a/myuw/templates/handlebars/card/instructor_schedule/course_cards.html
+++ b/myuw/templates/handlebars/card/instructor_schedule/course_cards.html
@@ -63,7 +63,7 @@
                 <li>
                     <div data-name="CourseCard" data-type="card" data-identifier="{{ curriculum_abbr }} {{course_number}} {{section_id}}">
                         <div id="course_wrapper{{@index}}">
-                            <a href="/teaching/{{term.year}},{{term.quarter}},{{curriculum_abbr}},{{course_number}}/{{section_id}}"><span class="courseIDtitle">{{ curriculum_abbr }} {{course_number}} {{section_id}}</span></a>
+                            <a href="/teaching/{{ term.year }},{{ term.quarter }},{{ curriculum_abbr }},{{ course_number }}/{{ section_id }}"><span class="courseIDtitle">{{ curriculum_abbr }} {{course_number}} {{section_id}}</span></a>
                         </div>
                     </div>
                 </li>

--- a/myuw/templates/handlebars/card/instructor_schedule/course_eval.html
+++ b/myuw/templates/handlebars/card/instructor_schedule/course_eval.html
@@ -42,7 +42,7 @@
                             <li class="evaluation-schedule">Report Available {{evaluation.report_available_date_display}}</li>
                         {{/if}}
                         {{#if evaluation.report_url}}
-                          <li><a href="{{evaluation.report_url}}" data-linklabel="{{curriculum_abbr}} {{course_number}} {{section_id}} Course Evaluation Report">View evaluation results report</a></li>
+                          <li><a href="{{ evaluation.report_url }}" data-linklabel="{{curriculum_abbr}} {{course_number}} {{section_id}} Course Evaluation Report">View evaluation results report</a></li>
                         {{/if}}
                         <li><strong>{{evaluation.response_rate_percent}}% Response rate</strong></li>
                     {{/if}}

--- a/myuw/templates/handlebars/card/instructor_schedule/course_grading.html
+++ b/myuw/templates/handlebars/card/instructor_schedule/course_grading.html
@@ -51,11 +51,11 @@
                         <div class="card-badge-value">
                             {{#if grading_status}}
                             {{#if grading_status.all_grades_submitted}}
-                                    <a href="{{grading_status.section_url}}" data-linklabel="GradePage {{curriculum_abbr}} {{course_number}} {{section_id}}" target="_blank">{{grading_status.submitted_count}} grade{{pluralize grading_status.submitted_count '' 's'}} submitted</a> by {{grading_status.submitted_by}} on <span class="text-nowrap">{{ grading_status.submitted_relative_date }}</span>
+                                    <a href="{{ grading_status.section_url }}" data-linklabel="GradePage {{curriculum_abbr}} {{course_number}} {{section_id}}" target="_blank">{{grading_status.submitted_count}} grade{{pluralize grading_status.submitted_count '' 's'}} submitted</a> by {{grading_status.submitted_by}} on <span class="text-nowrap">{{ grading_status.submitted_relative_date }}</span>
                             {{else}}
-                                {{#if grading_status.unsubmitted_count}}<a href="{{grading_status.section_url}}"  data-linklabel="GradePage {{curriculum_abbr}} {{course_number}} {{section_id}}" target="_blank">{{grading_status.unsubmitted_count}} grade{{pluralize grading_status.unsubmitted_count '' 's'}} to submit </a>
+                                {{#if grading_status.unsubmitted_count}}<a href="{{ grading_status.section_url }}"  data-linklabel="GradePage {{curriculum_abbr}} {{course_number}} {{section_id}}" target="_blank">{{grading_status.unsubmitted_count}} grade{{pluralize grading_status.unsubmitted_count '' 's'}} to submit </a>
                                 {{else}}
-                                {{#if allows_secondary_grading}}{{grading_status.grading_status}}{{else}}Grading for secondary section is disabled. <a class="text-nowrap" href="{{grading_status.section_url}}" data-linklabel="GradePage {{curriculum_abbr}} {{course_number}} {{section_id}}"  target="_blank">Grade primary section</a>.{{/if}}
+                                {{#if allows_secondary_grading}}{{grading_status.grading_status}}{{else}}Grading for secondary section is disabled. <a class="text-nowrap" href="{{ grading_status.section_url }}" data-linklabel="GradePage {{curriculum_abbr}} {{course_number}} {{section_id}}"  target="_blank">Grade primary section</a>.{{/if}}
                                 {{/if}}
                             {{/if}}
                             <a href="https://itconnect.uw.edu/learn/tools/gradepage/" rel="{{curriculum_abbr}} {{course_number}} {{section_id}}" class="gradepage_help_link" target="_blank" data-linklabel="GradePage Help"><i class="fa fa-question-circle" aria-hidden="true"></i></a>
@@ -67,7 +67,7 @@
                         {{#if grading_period_is_past}}
                             <div class="card-badge-value">
                                 {{#if grading_status}}
-                                {{#if grading_status.all_grades_submitted}}<a href="{{grading_status.section_url}}" data-linklabel="GradePage {{curriculum_abbr}} {{course_number}} {{section_id}}" target="_blank">{{grading_status.submitted_count}} grade{{pluralize grading_status.submitted_count '' 's'}} submitted</a> by {{grading_status.submitted_by}} on <span class="text-nowrap">{{ grading_status.submitted_relative_date }}</span>
+                                {{#if grading_status.all_grades_submitted}}<a href="{{ grading_status.section_url }}" data-linklabel="GradePage {{curriculum_abbr}} {{course_number}} {{section_id}}" target="_blank">{{grading_status.submitted_count}} grade{{pluralize grading_status.submitted_count '' 's'}} submitted</a> by {{grading_status.submitted_by}} on <span class="text-nowrap">{{ grading_status.submitted_relative_date }}</span>
                                     <br />
                                 {{/if}}
                                 <div class="myuw-note">Grade submission for {{capitalizeString quarter}} {{year}} closed <span class="text-nowrap">{{grade_submission_deadline_date}}</span></div>

--- a/myuw/templates/handlebars/card/instructor_schedule/course_resource/class_website.html
+++ b/myuw/templates/handlebars/card/instructor_schedule/course_resource/class_website.html
@@ -4,10 +4,10 @@
 
             {{#if class_website_data.not_found}}
                 <span class="card-badge-value">
-                    <a class="course_website" href="{{class_website_url}}" rel="{{ curriculum_abbr }} {{course_number}} {{section_id}}" target="_blank" data-linklabel="Course Website: {{ curriculum_abbr }} {{course_number}} {{section_id}}"> View class website</a>
+                    <a class="course_website" href="{{ class_website_url }}" rel="{{ curriculum_abbr }} {{course_number}} {{section_id}}" target="_blank" data-linklabel="Course Website: {{ curriculum_abbr }} {{course_number}} {{section_id}}"> View class website</a>
                     <div class="myuw-error"><i class="fa fa-warning" aria-hidden="true"></i> There is an error reaching website.
                       {{#unless past_term}}
-                        <a class="course_website_update" href="javascript:void(0);" data-href="https://sdb.admin.uw.edu/sisMyUWClass/uwnetid/pop/classurl.aspx?quarter={{quarter}}+{{year}}&amp;sln={{ sln }}&amp;chanid=11" rel="{{ curriculum_abbr }} {{course_number}} {{section_id}}" data-linklabel="Update Course Website: {{ curriculum_abbr }} {{course_number}} {{section_id}}">Please check URL</a>
+                        <a class="course_website_update" href="javascript:void(0);" data-href="https://sdb.admin.uw.edu/sisMyUWClass/uwnetid/pop/classurl.aspx?quarter={{ quarter }}+{{ year }}&amp;sln={{ sln }}&amp;chanid=11" rel="{{ curriculum_abbr }} {{course_number}} {{section_id}}" data-linklabel="Update Course Website: {{ curriculum_abbr }} {{course_number}} {{section_id}}">Please check URL</a>
                       {{/unless}}
                     </div>
                 </span>
@@ -15,9 +15,9 @@
                 {{#if class_website_url}}
 
                     <span class="card-badge-value">
-                        <a class="course_website" href="{{class_website_url}}" rel="{{ curriculum_abbr }} {{course_number}} {{section_id}}" target="_blank" data-linklabel="Course Website: {{ curriculum_abbr }} {{course_number}} {{section_id}}">{{#if class_website_data.title}}{{ class_website_data.title }}{{else}}View class website{{/if}}</a>
+                        <a class="course_website" href="{{ class_website_url }}" rel="{{ curriculum_abbr }} {{course_number}} {{section_id}}" target="_blank" data-linklabel="Course Website: {{ curriculum_abbr }} {{course_number}} {{section_id}}">{{#if class_website_data.title}}{{ class_website_data.title }}{{else}}View class website{{/if}}</a>
                       {{#unless past_term}}
-                        <span class="course-website-update"><a class="course_website_update" href="javascript:void(0);" data-href="https://sdb.admin.uw.edu/sisMyUWClass/uwnetid/pop/classurl.aspx?quarter={{quarter}}+{{year}}&amp;sln={{ sln }}&amp;chanid=11" rel="{{ curriculum_abbr }} {{course_number}} {{section_id}}" data-linklabel="Update Course Website: {{ curriculum_abbr }} {{course_number}} {{section_id}}">Update</a></span>
+                        <span class="course-website-update"><a class="course_website_update" href="javascript:void(0);" data-href="https://sdb.admin.uw.edu/sisMyUWClass/uwnetid/pop/classurl.aspx?quarter={{ quarter }}+{{ year }}&amp;sln={{ sln }}&amp;chanid=11" rel="{{ curriculum_abbr }} {{course_number}} {{section_id}}" data-linklabel="Update Course Website: {{ curriculum_abbr }} {{course_number}} {{section_id}}">Update</a></span>
                       {{/unless}}
                     </span>
 
@@ -27,7 +27,7 @@
                         None provided
                     {{else}}
                         {{#if sln}}
-                            <a class="course_website_update" href="javascript:void(0);" data-href="https://sdb.admin.uw.edu/sisMyUWClass/uwnetid/pop/classurl.aspx?quarter={{quarter}}+{{year}}&amp;sln={{ sln }}&amp;chanid=11" rel="{{ curriculum_abbr }} {{course_number}} {{section_id}}" data-linklabel="Add Course Website: {{ curriculum_abbr }} {{course_number}} {{section_id}}">Add</a>
+                            <a class="course_website_update" href="javascript:void(0);" data-href="https://sdb.admin.uw.edu/sisMyUWClass/uwnetid/pop/classurl.aspx?quarter={{ quarter }}+{{ year }}&amp;sln={{ sln }}&amp;chanid=11" rel="{{ curriculum_abbr }} {{course_number}} {{section_id}}" data-linklabel="Add Course Website: {{ curriculum_abbr }} {{course_number}} {{section_id}}">Add</a>
                             <div class="myuw-note add-delay-message">Up to one hour delay to show on MyUW</div>
                         {{/if}}
                     {{/if}}

--- a/myuw/templates/handlebars/card/instructor_schedule/course_resource/course_class_list.html
+++ b/myuw/templates/handlebars/card/instructor_schedule/course_resource/course_class_list.html
@@ -10,7 +10,7 @@
             <div class="col-sm-9">
                 <div class="myuw-card-row-content">
                     <div class="card-badge-value">
-                        <span>{{ current_enrollment }} of {{ limit_estimate_enrollment }} {{#if current_enrollment }}</span> <a target="_blank" href="/teaching/{{year}},{{quarter}},{{ curriculum_abbr }},{{course_number}}/{{section_id}}/students" class="course_class_list" rel="{{ curriculum_abbr }} {{course_number}} {{section_id}}">View class list</a>{{/if}}
+                        <span>{{ current_enrollment }} of {{ limit_estimate_enrollment }} {{#if current_enrollment }}</span> <a target="_blank" href="/teaching/{{ year }},{{ quarter }},{{ curriculum_abbr }},{{ course_number }}/{{ section_id }}/students" class="course_class_list" rel="{{ curriculum_abbr }} {{course_number}} {{section_id}}">View class list</a>{{/if}}
                     </div>
                 </div>
             </div>

--- a/myuw/templates/handlebars/card/instructor_schedule/course_resource/online_tools.html
+++ b/myuw/templates/handlebars/card/instructor_schedule/course_resource/online_tools.html
@@ -1,4 +1,4 @@
 {% load templatetag_handlebars %}
     {% verbatim %}
-        {{#if canvas_url}}<span class="card-badge-value"><a href="{{canvas_url}}" class="course_canvas_site" rel="{{ curriculum_abbr }} {{course_number}} {{section_id}}" data-linklabel="Course Canvas: {{ curriculum_abbr }} {{course_number}} {{section_id}}">Course Canvas</a></span>{{/if}}
+        {{#if canvas_url}}<span class="card-badge-value"><a href="{{ canvas_url }}" class="course_canvas_site" rel="{{ curriculum_abbr }} {{course_number}} {{section_id}}" data-linklabel="Course Canvas: {{ curriculum_abbr }} {{course_number}} {{section_id}}">Course Canvas</a></span>{{/if}}
     {% endverbatim %}

--- a/myuw/templates/handlebars/card/instructor_schedule/course_resource/textbooks.html
+++ b/myuw/templates/handlebars/card/instructor_schedule/course_resource/textbooks.html
@@ -1,6 +1,6 @@
 {% load templatetag_handlebars %}
     {% verbatim %}
     {{#if sln}}
-        <span class="card-badge-value"><a class="show_course_textbook" href="/textbooks/{{year}},{{quarter}}{{#if summer_term}},{{toLowerCase summer_term}}{{/if}}#{{curriculum_abbr}}{{course_number}}{{section_id}}" class="course_textbooks">Textbooks</a></span>
+        <span class="card-badge-value"><a class="show_course_textbook" href="/textbooks/{{ year }},{{ quarter }}{{#if summer_term}},{{toLowerCase summer_term}}{{/if}}#{{ curriculum_abbr }}{{ course_number }}{{ section_id }}" class="course_textbooks">Textbooks</a></span>
     {{/if}}
     {% endverbatim %}

--- a/myuw/templates/handlebars/card/instructor_schedule/course_sche_panel.html
+++ b/myuw/templates/handlebars/card/instructor_schedule/course_sche_panel.html
@@ -40,7 +40,7 @@
                                         {% include "handlebars/card/schedule/course_sche_col_bldg.html" %}
                                         <td class="course-location-info">
                                             {{#if classroom_info_url}}
-                                                <a href="{{classroom_info_url}}" data-linklabel="{{ building }} {{ room }} - Room Info">Room info</a>
+                                                <a href="{{ classroom_info_url }}" data-linklabel="{{ building }} {{ room }} - Room Info">Room info</a>
                                             {{/if}}
                                         </td>
                                     {{/if}}
@@ -83,7 +83,7 @@
                                             {{#if latitude}}<a href="http://maps.google.com/maps?q={{ latitude }},{{ longitude }}+({{encodeForMaps building_name }})&z=18" class="show_map" rel="{{building_name}}" data-linklabel="{{ building }} - Google Maps" title="Map {{building_name}}">{{/if}}{{building}}{{#if latitude}} {{room_number}}</a>{{/if}}
                                         </td>
                                         <td class="course-location-info">
-                                            {{#if classroom_info_url}}<a href="{{classroom_info_url}}" data-linklabel="{{ building }} {{ room_number }}">Room info</a>{{/if}}
+                                            {{#if classroom_info_url}}<a href="{{ classroom_info_url }}" data-linklabel="{{ building }} {{ room_number }}">Room info</a>{{/if}}
                                         </td>
                                     </tbody>
                                 </table>
@@ -99,7 +99,7 @@
 
                 {{#unless final_exam.no_exam_or_nontraditional}}{{#unless final_exam.is_confirmed}}
                     {{#if sln}}
-                        <a href="https://sdb.admin.uw.edu/sisMyUWClass/uwnetid/{{netid}}/finalexam.asp?{{capitalizeString quarter}}+{{year}}&sln={{sln}}" target="_blank" data-linklabel="Confirm Final: {{ curriculum_abbr }} {{course_number}} {{section_id}}">Confirm final exam</a>
+                        <a href="https://sdb.admin.uw.edu/sisMyUWClass/uwnetid/{{ netid }}/finalexam.asp?{{capitalizeString quarter}}+{{ year }}&sln={{sln}}" target="_blank" data-linklabel="Confirm Final: {{ curriculum_abbr }} {{course_number}} {{section_id}}">Confirm final exam</a>
                     {{/if}}
                 {{/unless}}{{/unless}}
             </div>

--- a/myuw/templates/handlebars/card/instructor_schedule/course_section.html
+++ b/myuw/templates/handlebars/card/instructor_schedule/course_section.html
@@ -18,7 +18,7 @@
 
                     <div class="course-meta">
                     {{# if sln}}
-                        <span class="myuw-meta course-sln">SLN <a href="https://sdb.admin.uw.edu/timeschd/uwnetid/sln.asp?QTRYR={{get_quarter_abbreviation ../quarter}}+{{../year}}&SLN={{ sln }}" target="_blank" data-linklabel="SLN {{ sln }}: {{ curriculum_abbr }} {{course_number}} {{section_id}}">{{ sln }}</a></span>
+                        <span class="myuw-meta course-sln">SLN <a href="https://sdb.admin.uw.edu/timeschd/uwnetid/sln.asp?QTRYR={{ get_quarter_abbreviation ../quarter}}+{{ ../year }}&SLN={{ sln }}" target="_blank" data-linklabel="SLN {{ sln }}: {{ curriculum_abbr }} {{course_number}} {{section_id}}">{{ sln }}</a></span>
                     {{/if}}
                         <span class="myuw-meta course-meeting-type c{{color_id}}Color">{{ meetings.0.type }}</span>
                     </div>
@@ -32,7 +32,7 @@
             <div class="c{{color_id}}Border"></div>
             <div class="fade-in">
                 <div id="course_wrapper{{@index}}" class="OFF" style="position:relative;">
-                <a href="/teaching/{{term.year}},{{term.quarter}},{{curriculum_abbr}},{{course_number}}/{{section_id}}"><span class="courseIDtitle">{{ curriculum_abbr }} {{course_number}} {{section_id}}</span></a>{{#if ../future_term}} ({{capitalizeString ../../quarter}} {{../../year}}){{/if}}{{#if ../past_term}} ({{capitalizeString ../../quarter}} {{../../year}}){{/if}}
+                <a href="/teaching/{{ term.year }},{{ term.quarter }},{{ curriculum_abbr }},{{ course_number }}/{{ section_id }}"><span class="courseIDtitle">{{ curriculum_abbr }} {{ course_number }} {{ section_id }}</span></a>{{#if ../future_term}} ({{capitalizeString ../../quarter}} {{../../year}}){{/if}}{{#if ../past_term}} ({{capitalizeString ../../quarter}} {{../../year}}){{/if}}
                 </div>
             </div>
         </div>

--- a/myuw/templates/handlebars/card/schedule/course_resource_panel.html
+++ b/myuw/templates/handlebars/card/schedule/course_resource_panel.html
@@ -5,20 +5,20 @@
     <ul class="unstyled-list">
         {{#if has_resources }}
             {{#if class_website_url}}
-                <li><a href="{{class_website_url}}" class="course_website" rel="{{ curriculum_abbr }} {{course_number}} {{section_id}}" data-linklabel="{{ curriculum_abbr }} {{ course_number }} Course Website">Course Website</a></li>
+                <li><a href="{{ class_website_url }}" class="course_website" rel="{{ curriculum_abbr }} {{course_number}} {{section_id}}" data-linklabel="{{ curriculum_abbr }} {{ course_number }} Course Website">Course Website</a></li>
              {{/if}}
 
              {{#if lib_subj_guide}}
-                 <li><a href="{{lib_subj_guide}}" class="lib_subject_guide" rel="{{ curriculum_abbr }} {{sln}} {{quarter}} {{year}}">Library Research Guides</a></li>
+                 <li><a href="{{ lib_subj_guide }}" class="lib_subject_guide" rel="{{ curriculum_abbr }} {{sln}} {{quarter}} {{year}}">Library Research Guides</a></li>
              {{/if}}
              
              {{#if canvas_url}}
-                 <li><a href="{{canvas_url}}" class="course_canvas_site" rel="{{ curriculum_abbr }} {{course_number}} {{section_id}}" data-linklabel="{{ curriculum_abbr }} {{ course_number }} Course Canvas">Course Canvas</a></li>
+                 <li><a href="{{ canvas_url }}" class="course_canvas_site" rel="{{ curriculum_abbr }} {{course_number}} {{section_id}}" data-linklabel="{{ curriculum_abbr }} {{ course_number }} Course Canvas">Course Canvas</a></li>
              {{/if}}
 
         {{/if}}
         {{#if sln}}
-            <li><a class="show_course_textbook" href="/textbooks/{{year}},{{quarter}}{{#if summer_term}},{{toLowerCase summer_term}}{{/if}}/{{curriculum_abbr}}{{course_number}}{{section_id}}">Textbooks</a></li>
+            <li><a class="show_course_textbook" href="/textbooks/{{ year }},{{ quarter }}{{#if summer_term}},{{toLowerCase summer_term}}{{/if}}/{{ curriculum_abbr }}{{ course_number }}{{ section_id }}">Textbooks</a></li>
         {{/if}}
     </ul>
 

--- a/myuw/templates/handlebars/card/schedule/final_panel.html
+++ b/myuw/templates/handlebars/card/schedule/final_panel.html
@@ -82,7 +82,7 @@
             <h5>Courses with final exam meeting times to be determined or courses with no final exam:</h5>
             {{#each tbd}}
             <div class="pull-left course-box">
-                <div class="c{{color_id}} course-info"><a href="/{{#if ../is_instructor}}teaching{{else}}academics{{/if}}/#{{curriculum_abbr}}-{{course_number}}-{{section_id}}" style="color: white;" class="show_section_card">{{curriculum_abbr}} {{course_number}}&nbsp;{{section_id}}</a></div>
+                <div class="c{{color_id}} course-info"><a href="/{{#if ../is_instructor}}teaching{{else}}academics{{/if}}/#{{ curriculum_abbr }}-{{ course_number }}-{{ section_id }}" style="color: white;" class="show_section_card">{{curriculum_abbr}} {{course_number}}&nbsp;{{section_id}}</a></div>
                 <div style="font-size:.8em; color:#555; text-align:center; margin-top:3px;">Room TBD</div>
             </div>
             {{/each}}

--- a/myuw/templates/handlebars/card/summary/schedule.html
+++ b/myuw/templates/handlebars/card/summary/schedule.html
@@ -6,7 +6,7 @@
           {{capitalizeString quarter}} {{year}} Teaching Schedule
         </h3>
         {{#if future_term}}<div class="course-meta"><div style="margin-top: 8px;"><a class="future-nav-link"
-              href="/teaching/{{year}},{{quarter}}" future-nav-target="{{year}},{{quarter}}"
+              href="/teaching/{{ year }},{{ quarter }}" future-nav-target="{{year}},{{quarter}}"
               data-linklabel="{{capitalizeString quarter}} {{year}} Teaching Details">View details</a></div></div>
             <p>You are teaching <strong>{{section_count}} course{{pluralize section_count '' 's'}}</strong> in {{capitalizeString quarter}} {{year}}. <br />
             First day of instruction is {{toFriendlyDate term.first_day_quarter}} ({{toFromNowDate term.first_day_quarter}})</p>{{/if}}
@@ -15,7 +15,7 @@
                   <div class="row">
                       <div class="col-sm-3">
                           <h4 class="myuw-card-row-heading" style="display:inline-block; margin-bottom:0px;"><div class="c{{color_id}} simplesquare" aria-hidden="true"></div><a
-                              href="/teaching/{{../year}},{{../quarter}}#{{curriculum_abbr}}-{{course_number}}-{{section_id}}"
+                              href="/teaching/{{ ../year }},{{ ../quarter }}#{{ curriculum_abbr }}-{{ course_number }}-{{ section_id }}"
                               class="future-nav-link" future-nav-target="{{../year}},{{../quarter}},{{curriculum_abbr}}-{{course_number}}-{{section_id}}">{{curriculum_abbr}} {{course_number}} {{section_id}}</a></h4><span style="font-size:12px;text-transform: uppercase;margin-left: 1.4em;">{{ meetings.0.type }}</span>
                       </div>
                       <div class="col-sm-9">
@@ -54,11 +54,11 @@
 
                                 {{#if ../../show_enrollment}}
                                     <td class="course-type">
-                                        {{#if ../current_enrollment}}<a target="_blank" href="/teaching/{{../../year}},{{../../quarter}},{{ ../curriculum_abbr }},{{../course_number}}/{{../section_id}}/students" class="course_class_list" rel="{{ ../curriculum_abbr }} {{../course_number}} {{../section_id}}">{{../current_enrollment}}</a>{{else}}0{{/if}}&nbsp;of&nbsp;{{../limit_estimate_enrollment}}
+                                        {{#if ../current_enrollment}}<a target="_blank" href="/teaching/{{ ../../year }},{{ ../../quarter }},{{ ../curriculum_abbr }},{{ ../course_number }}/{{ ../section_id }}/students" class="course_class_list" rel="{{ ../curriculum_abbr }} {{../course_number}} {{../section_id}}">{{../current_enrollment}}</a>{{else}}0{{/if}}&nbsp;of&nbsp;{{../limit_estimate_enrollment}}
                                     </td>
                                 {{else}}
                                     <td class="course-type">
-                                        <a target="_blank" href="/teaching/{{../../year}},{{../../quarter}},{{ ../curriculum_abbr }},{{../course_number}}/{{../section_id}}/students" class="course_class_list" rel="{{ ../curriculum_abbr }} {{../course_number}} {{../section_id}}">Class list</a>
+                                        <a target="_blank" href="/teaching/{{ ../../year }},{{ ../../quarter }},{{ ../curriculum_abbr }},{{ ../course_number }}/{{ ../section_id }}/students" class="course_class_list" rel="{{ ../curriculum_abbr }} {{../course_number}} {{../section_id}}">Class list</a>
                                     </td>
                                 {{/if}}
                             {{/if}}
@@ -72,10 +72,10 @@
             {{/each}}
 
             {{#if has_section_references }}
-                <p>You are an instructor of record on <strong>{{ total_section_refs }}</strong> courses this quarter. <a href="/teaching/{{year}},{{quarter}}">View list of courses.</a></p>
+                <p>You are an instructor of record on <strong>{{ total_section_refs }}</strong> courses this quarter. <a href="/teaching/{{ year }},{{ quarter }}">View list of courses.</a></p>
             {{/if}}
 
-            <div class="future-quarter-links" style="margin-top:16px;"><a href="/academic_calendar/#{{year}},{{capitalizeString quarter}}">View {{capitalizeString quarter}} {{year}} important dates and deadlines.</a></div>
+            <div class="future-quarter-links" style="margin-top:16px;"><a href="/academic_calendar/#{{ year }},{{capitalizeString quarter}}">View {{capitalizeString quarter}} {{year}} important dates and deadlines.</a></div>
         </div>
     </div>
 {% endtplhandlebars %}


### PR DESCRIPTION
all this does is add spaces to context variable references inside quoted href attributes. 
we need to do this to preserve quotes around hrefs in the template_preprocesss output.
the problem is with no spaces the preprocessor removes href quotes, so if after context variable substitution the href contains a space, we're screwed.

this is a little fragile going forward, so maybe we need to add a travis test to catch this.