### PR TITLE
fixes MUWM-3968. only hides <h2>s of the heading class

### DIFF
--- a/myuw/static/css/boilerplate.less
+++ b/myuw/static/css/boilerplate.less
@@ -77,7 +77,7 @@ body { padding: 0; margin: 0; font-family: "Open Sans",Helvetica,Arial,Verdana,s
 
     .container { max-width: none; }
 
-    .heading-page, .myuw-heading-page { display: none;
+    h2.heading-page, h2.myuw-heading-page { display: none;
         @media @desktop { display: block; margin-top: 0; }
     }
 }


### PR DESCRIPTION
Can test this on personal build by logging in as "bill" and viewing the Textbooks page. 

The heading "Teaching" should remain when going to mobile view, while the main page title above it becomes hidden.