### PR TITLE
Hotfix/muwm 3988

### DIFF
--- a/myuw/static/css/course_card.less
+++ b/myuw/static/css/course_card.less
@@ -67,19 +67,21 @@ c8a #473EC5;
     top: 0;
     right: 0;
 
-    .course-sln {
-        a {
-            color:inherit;
-            text-decoration: underline;
-        }
-    }
-
     .course-meeting-type {
         margin-left: 16px;
         padding:2px 4px 2px 4px;
         border: 1px solid #eee;
     }
 }
+
+.course-sln {
+    a {
+        color:inherit;
+        text-decoration: underline;
+    }
+}
+
+
 
 
 .table-course-schedule {
@@ -95,7 +97,6 @@ c8a #473EC5;
         &.course-final-date { min-width: 4em; }
         &.course-days { text-align:left; width: 4.5em; }
         &.course-section {
-            width: 4.2em;
             white-space: nowrap;
 
             a {
@@ -106,6 +107,7 @@ c8a #473EC5;
         &.course-location { width: 6em; }
         &.course-enrollment {
             width: 6em;
+            text-align: right;
 
             .course_class_list {
                 margin-left: auto;
@@ -113,7 +115,7 @@ c8a #473EC5;
         }
         &.course-type { text-align: left; text-transform: capitalize; }
         &.course-location-info { width: 6em; }
-        &.course-sln { text-align: right; }
+        &.course-sln {  }
     }
 
     tr:last-child td { padding-bottom: 0; }
@@ -133,7 +135,7 @@ c8a #473EC5;
     display: block;
 }
 
-.fa-question-circle {color:#8f9bcc;}
+.fa-question-circle { color: #8f9bcc; }
 
 
 /* Message text */
@@ -143,15 +145,21 @@ c8a #473EC5;
 /* Teaching Schedule Summary Card */
 .teaching-schedule-summary.myuw-card {
 
-    .meeting-type {
-        font-size: 12px;
-        text-transform: uppercase;
+    .course-meeting-type {
         margin-left: 1.4em;
+        margin-right: 1em;
+    }
+
+    .section-meta {
+        position: absolute;
+        top: 0;
+        right: 0;
     }
 
     @media @two-column {
 
-        .meeting-type {
+        .section-meta {
+            position: relative;
             display: block;
         }
         .myuw-card-title {
@@ -173,14 +181,13 @@ c8a #473EC5;
 
     .secondary-section-disclosure {
 
-        .myuw-card-row-content {
+        padding-top: 8px;
+        padding-left: 8px;
 
-            padding-left: 8px;
-
-            @media @two-column {
-                padding-left: 16px;
-            }
+        @media @two-column {
+            padding-left: 16px;
         }
+
 
     }
 }

--- a/myuw/static/css/course_card.less
+++ b/myuw/static/css/course_card.less
@@ -88,6 +88,9 @@ c8a #473EC5;
 
     td {
         padding: 0 8px 8px 0;
+        vertical-align: top;
+
+        &:last-child { padding-right: 0; }
 
         &.course-final-date { min-width: 4em; }
         &.course-days { text-align:left; width: 4.5em; }
@@ -100,7 +103,7 @@ c8a #473EC5;
             }
         }
         &.course-time { width: 8.4em; }
-        &.course-location { width: 6em; text-align: right; padding-right: 16px; }
+        &.course-location { width: 6em; }
         &.course-enrollment {
             width: 6em;
 

--- a/myuw/static/css/course_card.less
+++ b/myuw/static/css/course_card.less
@@ -137,16 +137,36 @@ c8a #473EC5;
 .inst-course-note { font-size: small; font-style: italic; }
 
 
-/* Secondary section summary */
-.teaching-schedule-summary {
+/* Teaching Schedule Summary Card */
+.teaching-schedule-summary.myuw-card {
 
-    .card-disclosure {
+    .meeting-type {
+        font-size: 12px;
+        text-transform: uppercase;
+        margin-left: 1.4em;
+    }
 
-        @media @two-column {
+    @media @two-column {
+
+        .meeting-type {
+            display: block;
+        }
+        .myuw-card-title {
+            margin-right: 4em;
+        }
+
+        .view-schedule-details {
+            position: absolute;
+            top: 8px;
+            right: 0;
+        }
+
+        .card-disclosure {
             margin-left: 1.3em;
-
         }
     }
+
+
 
     .secondary-section-disclosure {
 

--- a/myuw/static/css/course_card.less
+++ b/myuw/static/css/course_card.less
@@ -97,10 +97,14 @@ c8a #473EC5;
         &.course-final-date { min-width: 4em; }
         &.course-days { text-align:left; width: 4.5em; }
         &.course-section {
-            white-space: nowrap;
-
-            a {
+            .section-id {
                 font-weight: bold;
+                white-space: nowrap;
+                display: inline-block;
+                margin-right: -4px;
+            }
+            .course-sln {
+                margin-left: 12px;
             }
         }
         &.course-time { width: 8.4em; }

--- a/myuw/static/css/mobile.less
+++ b/myuw/static/css/mobile.less
@@ -2119,25 +2119,7 @@ th.mailman-sections-column { width: 99%; }
     margin-bottom: 10px;
 }
 
-/*** Teaching Summary Card ***/
-.teaching-schedule-summary.myuw-card {
-    .myuw-card-title {
-        margin-right: 4em;
-    }
 
-    .meeting-type {
-        font-size: 12px;
-        text-transform: uppercase;
-        margin-left: 1.4em;
-
-        @media @phablet {
-            display: block;
-        }
-    }
-
-//    @media only screen and (max-width: 815px) { }
-
-}
 
 
 /*** footer ***/

--- a/myuw/static/css/typography.less
+++ b/myuw/static/css/typography.less
@@ -75,6 +75,33 @@ abbr[title] {
     font-size: @fontsize-small;
 }
 
+
+.myuw-ratio-minimized {
+    display: inline;
+
+    @media @two-column {
+        display: none;
+    }
+}
+
+.myuw-ratio-expanded {
+    overflow: hidden;
+    display: inline-block;
+    width: 0;
+    position: absolute;
+    text-indent: -500px;
+
+    @media @two-column {
+        text-indent: 0;
+        display: inline;
+        position: relative;
+        width: auto;
+    }
+}
+
+
+
+
 .myuw-label-disabled {
 
 }

--- a/myuw/static/css/typography.less
+++ b/myuw/static/css/typography.less
@@ -76,6 +76,8 @@ abbr[title] {
 }
 
 
+/** Responsive system alternates between the contents of the minimized
+**  and expanded version. Using " of " and "/" as the defaults **/
 .myuw-ratio-minimized {
     display: inline;
 

--- a/myuw/templates/handlebars/card/summary/schedule.html
+++ b/myuw/templates/handlebars/card/summary/schedule.html
@@ -10,14 +10,14 @@
                 You are not teaching any courses {{capitalizeString quarter}} {{year}}.
             {{else}}
                 {{#if future_term}}
-                    <div class="course-meta"><div style="margin-top: 8px;"><a class="future-nav-link"
-                    href="/teaching/{{ year }},{{ quarter }}" future-nav-target="{{year}},{{quarter}}"
-                    data-linklabel="{{capitalizeString quarter}} {{year}} Teaching Details">View details</a></div></div>
                     <p>You are teaching <strong>{{section_count}} course{{pluralize section_count '' 's'}}</strong> in {{capitalizeString quarter}} {{year}}. <br />
                     First day of instruction is {{toFriendlyDate first_day_quarter}} ({{toFromNowDate first_day_quarter}})</p>
+                    <div class="view-schedule-details"><a class="future-nav-link"
+                    href="/teaching/{{ year }},{{ quarter }}" future-nav-target="{{year}},{{quarter}}"
+                    data-linklabel="{{capitalizeString quarter}} {{year}} Teaching Details">View details</a></div>
                 {{/if}}
                 {{#each sections}}
-                    {{#unless under_disclosure}}
+                    {{#unless under_disclosure}} <!-- If primary section -->
                         <div class="myuw-card-section-fulldivider {{#if @last}}last{{/if}}">
                             {{> summary_section_panel }}
 

--- a/myuw/templates/handlebars/card/summary/schedule.html
+++ b/myuw/templates/handlebars/card/summary/schedule.html
@@ -19,10 +19,12 @@
                 {{#each sections}}
                     {{#unless under_disclosure}} <!-- If primary section -->
                         <div class="myuw-card-section-fulldivider {{#if @last}}last{{/if}}">
+                            <div class="row">
                             {{> summary_section_panel }}
+                            </div>
 
                             {{#if linked_secondaries}}
-                                <div class="row">
+                                <div class="row"> <!-- one row for disclosure link and table-->
                                     <div class="col-sm-12">
                                         <div class="myuw-card-row-content">
                                             <div class="card-disclosure">
@@ -32,17 +34,33 @@
                                                    class="fa fa-caret-right"></i>Secondary sections for
                                                    {{ curriculum_abbr }} {{course_number}} {{section_id}}</a>
                                             </div>
+
+                                            <div id="secondary_{{section_label}}" class="collapse secondary-section-disclosure"
+                                             rel="{{ curriculum_abbr }} {{course_number}} {{section_id}}"
+                                             aria-label="Secondary sections for {{ curriculum_abbr }} {{course_number}} {{section_id}}">
+
+                                                 <table class="table-course-schedule">
+                                                     <thead class="sr-only">
+                                                         <tr>
+                                                             <th>Section</th>
+                                                             <th>SLN</th>
+                                                             <th>Section Type</th>
+                                                             <th>Day(s)</th>
+                                                             <th>Time</th>
+                                                             <th>Location</th>
+                                                             <th>Enrollment</th>
+                                                         </tr>
+                                                     </thead>
+
+                                                     <tbody class="tbody-course-schedule">
+                                                {{#each linked_secondaries}}
+                                                    {{> summary_section_panel }}
+                                                {{/each}}
+                                                    </tbody>
+                                                </table>
+                                            </div>
                                         </div>
                                     </div>
-                                </div>
-
-                                <div id="secondary_{{section_label}}" class="collapse secondary-section-disclosure"
-                                     rel="{{ curriculum_abbr }} {{course_number}} {{section_id}}"
-                                     aria-label="Secondary sections for {{ curriculum_abbr }} {{course_number}} {{section_id}}">
-
-                                    {{#each linked_secondaries}}
-                                        {{> summary_section_panel }}
-                                    {{/each}}
                                 </div>
 
                             {{/if}}

--- a/myuw/templates/handlebars/card/summary/schedule.html
+++ b/myuw/templates/handlebars/card/summary/schedule.html
@@ -43,7 +43,6 @@
                                                      <thead class="sr-only">
                                                          <tr>
                                                              <th>Section</th>
-                                                             <th>SLN</th>
                                                              <th>Section Type</th>
                                                              <th>Day(s)</th>
                                                              <th>Time</th>

--- a/myuw/templates/handlebars/card/summary/section_panel.html
+++ b/myuw/templates/handlebars/card/summary/section_panel.html
@@ -72,7 +72,7 @@
                                             {{#unless ../current_enrollment}}0{{#unless ../is_independent_study}}&nbsp;of&nbsp;{{../limit_estimate_enrollment}}{{/unless}}
                                             {{else}}
                                                 <a target="_blank" href="/teaching/{{ @root.year }},{{ @root.quarter }},{{ ../curriculum_abbr }},{{ ../course_number }}/{{ ../section_id }}/students" title="View class list"
-                                                   class="course_class_list" rel="{{ ../curriculum_abbr }} {{../course_number}} {{../section_id}}">{{../current_enrollment}}{{#unless ../is_independent_study}}&nbsp;of&nbsp;{{../limit_estimate_enrollment}}{{/unless}}</a>
+                                                   class="course_class_list" rel="{{ ../curriculum_abbr }} {{../course_number}} {{../section_id}}">{{../current_enrollment}}{{#unless ../is_independent_study}}<span class="myuw-ratio-expanded"> of </span><span class="myuw-ratio-minimized" aria-hidden="true">/</span>{{../limit_estimate_enrollment}}{{/unless}}</a>
                                             {{/unless}}
                                         {{/if}}
                                     {{/if}}

--- a/myuw/templates/handlebars/card/summary/section_panel.html
+++ b/myuw/templates/handlebars/card/summary/section_panel.html
@@ -59,7 +59,7 @@
 
                                 {{#unless no_meeting}}
                                     {{#if building_tbd}}
-                                        <td class="course-loc-tbd">Room to be arranged</td>
+                                        <td class="course-loc-tbd">Room <abbr title="To be determined">TBD</abbr></td>
                                     {{else}}
                                         {% include "handlebars/card/schedule/course_sche_col_bldg.html" %}
                                     {{/if}}

--- a/myuw/templates/handlebars/card/summary/section_panel.html
+++ b/myuw/templates/handlebars/card/summary/section_panel.html
@@ -34,15 +34,11 @@
                                 {{#if ../under_disclosure}}
                                 <td class="course-section">
                                     {{#if @first }}
-                                        <div class="c{{../color_id}} minirectangle" aria-hidden="true"></div><a
+                                        <div class="section-id"><div class="c{{../color_id}} minirectangle" aria-hidden="true"></div><a
                                              href="/teaching/{{ @root.year }},{{ @root.quarter }}#{{ ../curriculum_abbr }}-{{ ../course_number }}-{{ ../section_id }}"
-                                             future-nav-target="{{@root.year}},{{@root.quarter}},{{../curriculum_abbr}}-{{../course_number}}-{{../section_id}}">{{../section_id}}</a>
-                                    {{/if}}
-                                </td>
+                                             future-nav-target="{{@root.year}},{{@root.quarter}},{{../curriculum_abbr}}-{{../course_number}}-{{../section_id}}">{{../section_id}}</a></div>
 
-                                <td class="course-sln">
-                                    {{#if @first }}
-                                        {{#if ../sln}}<a href="http://sdb.admin.uw.edu/timeschd/uwnetid/sln.asp?QTRYR={{ get_quarter_abbreviation @root.quarter }}+{{ @root.year }}&SLN={{ ../sln }}" title="Time Schedule for SLN {{../sln}}" target="_blank" data-linklabel="SLN {{../sln}}: {{../curriculum_abbr}} {{../course_number}} {{../section_id}}">{{../sln}}</a>{{/if}}
+                                             {{#if ../sln}}<span class="course-sln"><a href="http://sdb.admin.uw.edu/timeschd/uwnetid/sln.asp?QTRYR={{ get_quarter_abbreviation @root.quarter }}+{{ @root.year }}&SLN={{ ../sln }}" title="Time Schedule for SLN {{../sln}}" target="_blank" data-linklabel="SLN {{../sln}}: {{../curriculum_abbr}} {{../course_number}} {{../section_id}}">{{../sln}}</a></span>{{/if}}
                                     {{/if}}
                                 </td>
 

--- a/myuw/templates/handlebars/card/summary/section_panel.html
+++ b/myuw/templates/handlebars/card/summary/section_panel.html
@@ -67,13 +67,11 @@
 
                                 <td class="course-enrollment">
                                     {{#if @first }}
-                                        {{#if is_prev_term_enrollment}}0  <!-- the current_enrollment value is of previous term -->
-                                             {{#unless ../is_independent_study}}&nbsp;of&nbsp;{{../limit_estimate_enrollment}}{{/unless}}
+                                        {{#if is_prev_term_enrollment}}0<!-- the current_enrollment value is of previous term -->{{#unless ../is_independent_study}}&nbsp;of&nbsp;{{../limit_estimate_enrollment}}{{/unless}}
                                         {{else}}
-                                            {{#unless ../current_enrollment}}0
-                                                {{#unless ../is_independent_study}}&nbsp;of&nbsp;{{../limit_estimate_enrollment}}{{/unless}}
+                                            {{#unless ../current_enrollment}}0{{#unless ../is_independent_study}}&nbsp;of&nbsp;{{../limit_estimate_enrollment}}{{/unless}}
                                             {{else}}
-                                                <a target="_blank" href="/teaching/{{ @root.year }},{{ @root.quarter }},{{ ../curriculum_abbr }},{{ ../course_number }}/{{ ../section_id }}/students"
+                                                <a target="_blank" href="/teaching/{{ @root.year }},{{ @root.quarter }},{{ ../curriculum_abbr }},{{ ../course_number }}/{{ ../section_id }}/students" title="View class list"
                                                    class="course_class_list" rel="{{ ../curriculum_abbr }} {{../course_number}} {{../section_id}}">{{../current_enrollment}}{{#unless ../is_independent_study}}&nbsp;of&nbsp;{{../limit_estimate_enrollment}}{{/unless}}</a>
                                             {{/unless}}
                                         {{/if}}
@@ -86,7 +84,7 @@
 
                                 <td class="course-sln">
                                     {{#if @first }}
-                                        {{#if ../sln}}<a href="http://sdb.admin.uw.edu/timeschd/uwnetid/sln.asp?QTRYR={{ get_quarter_abbreviation @root.quarter }}+{{ @root.year }}&SLN={{ ../sln }}" target="_blank" data-linklabel="SLN {{../sln}}: {{../curriculum_abbr}} {{../course_number}} {{../section_id}}">{{../sln}}</a>{{/if}}
+                                        {{#if ../sln}}<a href="http://sdb.admin.uw.edu/timeschd/uwnetid/sln.asp?QTRYR={{ get_quarter_abbreviation @root.quarter }}+{{ @root.year }}&SLN={{ ../sln }}" title="Time Schedule for SLN {{../sln}}" target="_blank" data-linklabel="SLN {{../sln}}: {{../curriculum_abbr}} {{../course_number}} {{../section_id}}">{{../sln}}</a>{{/if}}
                                     {{/if}}
                                 </td>
                             </tr>

--- a/myuw/templates/handlebars/card/summary/section_panel.html
+++ b/myuw/templates/handlebars/card/summary/section_panel.html
@@ -1,42 +1,34 @@
 {% load templatetag_handlebars %}
     {% tplhandlebars "summary_section_panel" %}
-    <div class="row">
+
     {{#unless under_disclosure}}
-    <!-- use two column layout -->
-        <div class="col-sm-3">
-            <h4 class="myuw-card-row-heading" style="display:inline-block;
-                margin-bottom:0px;"><div class="c{{color_id}} simplesquare" aria-hidden="true"></div><a href="/teaching/{{ @root.year }},{{ @root.quarter }}#{{ curriculum_abbr }}-{{ course_number }}-{{ section_id }}"
+    <!-- use two column layout for primary sections -->
+        <div class="col-sm-4">
+            <h4 class="myuw-card-row-heading"><div class="c{{color_id}} simplesquare" aria-hidden="true"></div><a href="/teaching/{{ @root.year }},{{ @root.quarter }}#{{ curriculum_abbr }}-{{ course_number }}-{{ section_id }}"
                 class="future-nav-link" future-nav-target="{{ @root.year }},{{ @root.quarter }},{{curriculum_abbr}}-{{course_number}}-{{section_id}}">{{curriculum_abbr}} <span class="text-nowrap">{{course_number}} {{section_id}}</span></a></h4>
-            <span class="meeting-type">{{ meetings.0.type }}</span>
+            <div class="section-meta">
+                <span class="myuw-meta course-meeting-type">{{ meetings.0.type }}</span>
+                {{#if sln}}
+                <span class="myuw-meta course-sln"><a href="http://sdb.admin.uw.edu/timeschd/uwnetid/sln.asp?QTRYR={{ get_quarter_abbreviation @root.quarter }}+{{ @root.year }}&SLN={{sln}}" title="Time Schedule for SLN {{sln}}" target="_blank" data-linklabel="SLN {{sln}}: {{curriculum_abbr}} {{course_number}} {{section_id}}">{{sln}}</a></span>
+                {{/if}}
+            </div>
         </div>
 
-        <div class="col-sm-9">
-
-    {{else}}
-    <!-- use one column layout -->
-        <div class="col-sm-12">
-
-    {{/unless}}
-
+        <div class="col-sm-8">
             <div class="myuw-card-row-content">
                 <table class="table-course-schedule">
                     <thead class="sr-only">
                         <tr>
-                            {{#if ../under_disclosure}}
-                                <th>Section</th>
-                            {{/if}}
                             <th>Day(s)</th>
                             <th>Time</th>
                             <th>Location</th>
                             <th>Enrollment</th>
-                            {{#if under_disclosure}}
-                                <th>Section Type</th>
-                            {{/if}}
-                            <th>SLN</th>
                         </tr>
                     </thead>
 
                     <tbody class="tbody-course-schedule">
+    {{/unless}}
+
                         {{#each meetings}}
                             <tr class="course-schedule-row">
                                 {{#if ../under_disclosure}}
@@ -47,6 +39,14 @@
                                              future-nav-target="{{@root.year}},{{@root.quarter}},{{../curriculum_abbr}}-{{../course_number}}-{{../section_id}}">{{../section_id}}</a>
                                     {{/if}}
                                 </td>
+
+                                <td class="course-sln">
+                                    {{#if @first }}
+                                        {{#if ../sln}}<a href="http://sdb.admin.uw.edu/timeschd/uwnetid/sln.asp?QTRYR={{ get_quarter_abbreviation @root.quarter }}+{{ @root.year }}&SLN={{ ../sln }}" title="Time Schedule for SLN {{../sln}}" target="_blank" data-linklabel="SLN {{../sln}}: {{../curriculum_abbr}} {{../course_number}} {{../section_id}}">{{../sln}}</a>{{/if}}
+                                    {{/if}}
+                                </td>
+
+                                <td class="course-type">{{ type }}</td>
                                 {{/if}}
 
                                 {{#if days_tbd }}
@@ -78,20 +78,13 @@
                                     {{/if}}
                                 </td>
 
-                                {{#if ../under_disclosure}}
-                                    <td class="course-type">{{ type }}</td>
-                                {{/if}}
-
-                                <td class="course-sln">
-                                    {{#if @first }}
-                                        {{#if ../sln}}<a href="http://sdb.admin.uw.edu/timeschd/uwnetid/sln.asp?QTRYR={{ get_quarter_abbreviation @root.quarter }}+{{ @root.year }}&SLN={{ ../sln }}" title="Time Schedule for SLN {{../sln}}" target="_blank" data-linklabel="SLN {{../sln}}: {{../curriculum_abbr}} {{../course_number}} {{../section_id}}">{{../sln}}</a>{{/if}}
-                                    {{/if}}
-                                </td>
                             </tr>
-                            {{/each}}
+                        {{/each}}
+
+    {{#unless under_disclosure}}<!-- close out table and div wrappers for primary sections -->
                     </tbody>
                 </table>
             </div>
         </div>
-    </div>
+    {{/unless}}
 {% endtplhandlebars %}


### PR DESCRIPTION
Rework of the HTML for the summary schedule to make it work responsively. Moves SLN to the left and makes it consistent with the existing style. Changes grid system to a 4/8 grid instead of 3/9.

Secondary sections are combined into a single table per primary section, instead of a separate table for each secondary section. This improves the layout. Combining secondary section names with the SLN allows them to collapse for mobile, similar to how the primary sections behave.

I'm also switched to "19/20" for the enrollment counts for mobile. It goes to "19 of 20" for desktop. 

@fanglinfang Can you add the truncation for "Laboratory" to "Lab" like we discussed?