### PR TITLE
Modified href source for class list link, fixing MUWM-4007

### DIFF
--- a/myuw/static/js/card/summary/schedule.js
+++ b/myuw/static/js/card/summary/schedule.js
@@ -85,7 +85,7 @@ var SummaryScheduleCard = {
             var left = window.screenX + 200;
             var top = window.screenY + 200;
 
-            window.open(ev.target.href, '_blank', 'scrollbars=1,resizable=1,width='+width+',height='+height+',left='+left+',top='+top);
+            window.open(ev.currentTarget.href, '_blank', 'scrollbars=1,resizable=1,width='+width+',height='+height+',left='+left+',top='+top);
 
             var course_id = ev.currentTarget.getAttribute("rel");
             course_id = course_id.replace(/[^a-z0-9]/gi, '_');


### PR DESCRIPTION
ev.target will reference the element that was clicked on. Unfortunately, if there's a child element of the a tag, this will then pass null to the window.open call as the child element will not have a href. To avoid this, we need to change ev.target to ev.currentTarget, as currentTarget will reference the element that had the listener/event handler (the a tag in this instance).

Reference for future reference:
https://developer.mozilla.org/en-US/docs/Web/API/Event/currentTarget