### PR TITLE
Bugfix/muwm 2455

### DIFF
--- a/myuw/templates/handlebars/card/schedule/visual.html
+++ b/myuw/templates/handlebars/card/schedule/visual.html
@@ -4,155 +4,159 @@
 
 <div class="card"  data-name="VisualScheduleCard" data-type="card">
     {{#if total_sections}}
-    <!--Adding SR only final exam schedule-->
-    <h3 class="sr-only">Your {{ucfirst quarter}} {{year}} final exam</h3>
    <!-- {{# if has_early_fall_start }}
     <a href="#" class="show_full_term_meetings">Show {{ucfirst quarter}} Full Term Courses</a>
     <a href="#" class="show_efs_meetings" style="display: none;">Show {{ucfirst quarter}} Early Fall Start Courses</a>
     {{/if}}-->
-    <div class="final_schedule_table sr-only">
-	<table>
-	    <thead>
-	        <tr>
-	            <th scope="col">Class</th>
-	            <th scope="col">Exam date and time</th>
-	            <th scope="col">Exam location</th>
-	        </tr>
-	    </thead>
-	    <tbody>
-	        {{#each list_data}}
-	        <tr>
-	            <th scope="row">{{curriculum_abbr}} {{course_number}} {{course_title}}</th>
-                    {{#with final_exam}}
-<td>{{formatDateAsDate start_date}}, {{formatDateAsTimeAMPM start_date}} - {{formatDateAsTimeAMPM end_date}}</td>
-                    <td>
-	                {{#if building_tbd}}
-	                Room TBD
-	                {{else}}
-	                {{#if latitude}}
-	                <a href="http://maps.google.com/maps?q={{latitude }},{{longitude }}+({{encodeForMaps building_name}})&z=18" target="_blank" class="show_map_modal" rel="{{building_name}}" data-linklabel="{{ building }} - Google Maps">
-	                    {{/if}}
-	                    {{building}} {{room_number}}
-	                    {{#if final_exam.latitude}}</a>{{/if}}
-	                {{/if}}
-	            </td>
-	            {{/with}}
-	        </tr>
-	        {{/each}}
-	    </tbody>
-	</table>
-    </div>
-	<div><p class="sr-only"><a href="#CourseCards">Skip the visual schedule and go to course cards</a></p>
-	</div>
-    <h3 id="quarter-info" aria-hidden="true">
-        {{ucfirst quarter}} {{year}} Schedule
-        {{#if summer_term}}
-        <span class="shortTitle">{{summer_term}}</span>
-        {{/if}}
+
+    <h3 id="quarter-info" >
+            {{ucfirst quarter}} {{year}} Schedule
+            {{#if summer_term}}
+            <span class="shortTitle">{{summer_term}}</span>
+            {{/if}}
     </h3>
-    <div id="schedule-tabs" class="schedule-period-module">
-		<ul class="nav nav-pills schedule-period-list">
-        {{#each schedule_periods }}
-        <li class="{{#equal ../active_period_id @key}} active{{/equal }}"><a class="schedule-period-anchor" href="#" data-period_id="{{ @key }}"><span class="schedule-period">{{#equal "finals" @key}}Finals {{ else }}{{ toMonthDay start_date }} - {{ toMonthDay end_date }} {{/equal }}</span></a></li>
-        {{/each }}
-		</ul>
-    </div>
-
-<div id="schedule_area">
-    {{#if display_hours }}
-    <!-- week view -->
-    <div class="visual-schedule {{schedule_hours_class}}" aria-hidden="true">
-	<div class="time-bar day-col2 hours-{{total_hours}} clearfix ">
-	    {{#each display_hours}}
-	    <div class="hour-label" style="position:absolute;top:{{time_percentage position ../start_time ../end_time }}%;"><p>{{format_schedule_hour hour hour_count}}</p>
-	    </div>
-	    {{/each}}
-	</div>
-
-	<div {{#if has_6_days}}class="six-day"{{else}}class="five-day"{{/if}}>
-	    <div class="day-label">MON</div>
-	    <div class="day-col hours-{{total_hours}}">
-	        {{ show_card_days_meetings monday start_time end_time }}
-	    </div>
-	</div>
-
-	<div {{#if has_6_days}}class="six-day"{{else}}class="five-day"{{/if}}>
-	    <div class="day-label">TUE</div>
-	    <div class="day-col hours-{{total_hours}}">
-	        {{ show_card_days_meetings tuesday start_time end_time }}
-	    </div>
-	</div>
-
-	<div {{#if has_6_days}}class="six-day"{{else}}class="five-day"{{/if}}>
-	    <div class="day-label">WED</div>
-	    <div class="day-col hours-{{total_hours}}">
-	        {{ show_card_days_meetings wednesday start_time end_time }}
-	    </div>
-	</div>
-
-	<div {{#if has_6_days}}class="six-day"{{else}}class="five-day"{{/if}}>
-	    <div class="day-label">THU</div>
-	    <div class="day-col hours-{{total_hours}}">
-	        {{ show_card_days_meetings thursday start_time end_time }}
-	    </div>
-	</div>
-
-	<div {{#if has_6_days}}class="six-day"{{else}}class="five-day"{{/if}}>
-	    <div class="day-label">FRI</div>
-	    <div class="day-col hours-{{total_hours}}">
-	        {{ show_card_days_meetings friday start_time end_time }}
-	    </div>
-	</div>
-
-	{{#if has_6_days}}
-	<div class="six-day">
-	    <div class="day-label">SAT</div>
-	    <div class="day-col hours-{{total_hours}}">
-	        {{ show_card_days_meetings saturday start_time end_time }}
-	    </div>
-	</div>
-	{{/if}}
-    </div>
-    {{/if}}
-    <!-- end week view -->
-
-    <!-- begin - if there are meetings with times to be arranged -->
-    {{#if courses_meeting_tbd }}
-    <div class="courseTBD" aria-hidden="true">
-        {{#each courses_meeting_tbd }}
-	    <div class="pull-left course-box">
-	        <div class="c{{color_id}} course-info"><a href="/{{#if ../is_instructor}}teaching{{else}}academics{{/if}}/#{{curriculum}}-{{course_number}}-{{section_id}}" style="color: white;" class="show_section_card">{{curriculum}} {{course_number}}&nbsp;{{section_id}}</a></div>
-	        <div style="font-size:.8em; color:#555; text-align:center; margin-top:3px;">Room TBD</div>
-	    </div>
-        {{/each}}
-    </div>
-    {{/if}}
-    <!-- end - if there are meetings with times to be arranged -->
-
+    <div><p class="sr-only"><a href="#CourseCards">Skip the visual schedule and go to course cards</a></p></div>
+    <div aria-hidden="true"><!-- Wrap the content under aria-hidden -->
+        <div id="schedule-tabs" class="schedule-period-module">
+    		<ul class="nav nav-pills schedule-period-list">
+            {{#each schedule_periods }}
+            <li class="{{#equal ../active_period_id @key}} active{{/equal }}"><a class="schedule-period-anchor" href="#" data-period_id="{{ @key }}"><span class="schedule-period">{{#equal "finals" @key}}Finals {{ else }}{{ toMonthDay start_date }} - {{ toMonthDay end_date }} {{/equal }}</span></a></li>
+            {{/each }}
+    		</ul>
+        </div>
+    
+        <div id="schedule_area">
+        {{#if display_hours }}
+        <!-- week view -->
+        <div class="visual-schedule {{schedule_hours_class}}" aria-hidden="true">
+    	<div class="time-bar day-col2 hours-{{total_hours}} clearfix ">
+    	    {{#each display_hours}}
+    	    <div class="hour-label" style="position:absolute;top:{{time_percentage position ../start_time ../end_time }}%;"><p>{{format_schedule_hour hour hour_count}}</p>
+    	    </div>
+    	    {{/each}}
+    	</div>
+    
+    	<div {{#if has_6_days}}class="six-day"{{else}}class="five-day"{{/if}}>
+    	    <div class="day-label">MON</div>
+    	    <div class="day-col hours-{{total_hours}}">
+    	        {{ show_card_days_meetings monday start_time end_time }}
+    	    </div>
+    	</div>
+    
+    	<div {{#if has_6_days}}class="six-day"{{else}}class="five-day"{{/if}}>
+    	    <div class="day-label">TUE</div>
+    	    <div class="day-col hours-{{total_hours}}">
+    	        {{ show_card_days_meetings tuesday start_time end_time }}
+    	    </div>
+    	</div>
+    
+    	<div {{#if has_6_days}}class="six-day"{{else}}class="five-day"{{/if}}>
+    	    <div class="day-label">WED</div>
+    	    <div class="day-col hours-{{total_hours}}">
+    	        {{ show_card_days_meetings wednesday start_time end_time }}
+    	    </div>
+    	</div>
+    
+    	<div {{#if has_6_days}}class="six-day"{{else}}class="five-day"{{/if}}>
+    	    <div class="day-label">THU</div>
+    	    <div class="day-col hours-{{total_hours}}">
+    	        {{ show_card_days_meetings thursday start_time end_time }}
+    	    </div>
+    	</div>
+    
+    	<div {{#if has_6_days}}class="six-day"{{else}}class="five-day"{{/if}}>
+    	    <div class="day-label">FRI</div>
+    	    <div class="day-col hours-{{total_hours}}">
+    	        {{ show_card_days_meetings friday start_time end_time }}
+    	    </div>
+    	</div>
+    
+    	{{#if has_6_days}}
+    	<div class="six-day">
+    	    <div class="day-label">SAT</div>
+    	    <div class="day-col hours-{{total_hours}}">
+    	        {{ show_card_days_meetings saturday start_time end_time }}
+    	    </div>
+    	</div>
+    	{{/if}}
+        </div>
+        {{/if}}
+        <!-- end week view -->
+    
         <!-- begin - if there are meetings with times to be arranged -->
-    {{#if courses_no_meeting }}
-    <div class="courseTBD" aria-hidden="true">
-        <p>Following courses have not specified a meeting time:</p>
-        {{#each courses_no_meeting }}
-	    <div class="pull-left course-box">
-	        <div class="c{{color_id}} course-info"><a href="/{{#if ../is_instructor}}teaching{{else}}academics{{/if}}/#{{curriculum}}-{{course_number}}-{{section_id}}" style="color: white;" class="show_section_card">{{curriculum}} {{course_number}}&nbsp;{{section_id}}</a></div>
-	        <div style="font-size:.8em; color:#555; text-align:center; margin-top:3px;">
-                {{#if building_tbd}}
-                    Room TBD
-                {{else}}
-                    {{#if latitude}}
-                        <a href="http://maps.google.com/maps?q={{ latitude }},{{ longitude }}+({{encodeForMaps building_name }})&z=18" class="show_visual_map" rel="{{building_name}}">
+        {{#if courses_meeting_tbd }}
+        <div class="courseTBD" aria-hidden="true">
+            {{#each courses_meeting_tbd }}
+    	    <div class="pull-left course-box">
+    	        <div class="c{{color_id}} course-info"><a href="/{{#if ../is_instructor}}teaching{{else}}academics{{/if}}/#{{curriculum}}-{{course_number}}-{{section_id}}" style="color: white;" class="show_section_card">{{curriculum}} {{course_number}}&nbsp;{{section_id}}</a></div>
+    	        <div style="font-size:.8em; color:#555; text-align:center; margin-top:3px;">Room TBD</div>
+    	    </div>
+            {{/each}}
+        </div>
+        {{/if}}
+        <!-- end - if there are meetings with times to be arranged -->
+    
+            <!-- begin - if there are meetings with times to be arranged -->
+        {{#if courses_no_meeting }}
+        <div class="courseTBD" aria-hidden="true">
+            <p>Following courses have not specified a meeting time:</p>
+            {{#each courses_no_meeting }}
+    	    <div class="pull-left course-box">
+    	        <div class="c{{color_id}} course-info"><a href="/{{#if ../is_instructor}}teaching{{else}}academics{{/if}}/#{{curriculum}}-{{course_number}}-{{section_id}}" style="color: white;" class="show_section_card">{{curriculum}} {{course_number}}&nbsp;{{section_id}}</a></div>
+    	        <div style="font-size:.8em; color:#555; text-align:center; margin-top:3px;">
+                    {{#if building_tbd}}
+                        Room TBD
+                    {{else}}
+                        {{#if latitude}}
+                            <a href="http://maps.google.com/maps?q={{ latitude }},{{ longitude }}+({{encodeForMaps building_name }})&z=18" class="show_visual_map" rel="{{building_name}}">
+                        {{/if}}
+                        {{building}} {{room}}
+                        {{#if latitude}}</a>{{/if}}
                     {{/if}}
-                    {{building}} {{room}}
-                    {{#if latitude}}</a>{{/if}}
-                {{/if}}
-            </div>
-	    </div>
-        {{/each}}
+                </div>
+    	    </div>
+            {{/each}}
+        </div>
+        {{/if}}
     </div>
-    {{/if}}
-</div>
-    <!-- end - if there are meetings with times to be arranged -->
+        <!-- end - if there are meetings with times to be arranged -->
+        
+        
+        <!--Adding SR only final exam schedule-->
+        <h4 class="sr-only">Your {{ucfirst quarter}} {{year}} final exam</h4>
+        <div class="final_schedule_table sr-only">
+    	<table>
+    	    <thead>
+    	        <tr>
+    	            <th scope="col">Class</th>
+    	            <th scope="col">Exam date and time</th>
+    	            <th scope="col">Exam location</th>
+    	        </tr>
+    	    </thead>
+    	    <tbody>
+    	        {{#each list_data}}
+    	        <tr>
+    	            <th scope="row">{{curriculum_abbr}} {{course_number}} {{course_title}}</th>
+                        {{#with final_exam}}
+    <td>{{formatDateAsDate start_date}}, {{formatDateAsTimeAMPM start_date}} - {{formatDateAsTimeAMPM end_date}}</td>
+                        <td>
+    	                {{#if building_tbd}}
+    	                Room TBD
+    	                {{else}}
+    	                {{#if latitude}}
+    	                <a href="http://maps.google.com/maps?q={{latitude }},{{longitude }}+({{encodeForMaps building_name}})&z=18" target="_blank" class="show_map_modal" rel="{{building_name}}" data-linklabel="{{ building }} - Google Maps">
+    	                    {{/if}}
+    	                    {{building}} {{room_number}}
+    	                    {{#if final_exam.latitude}}</a>{{/if}}
+    	                {{/if}}
+    	            </td>
+    	            {{/with}}
+    	        </tr>
+    	        {{/each}}
+    	    </tbody>
+    	</table>
+        </div>
+    </div>
 {{/if}}
 </div>
 {% endtplhandlebars %}

--- a/myuw/templates/handlebars/card/schedule/visual.html
+++ b/myuw/templates/handlebars/card/schedule/visual.html
@@ -16,7 +16,7 @@
             {{/if}}
     </h3>
     <div><p class="sr-only"><a href="#CourseCards">Skip the visual schedule and go to course cards</a></p></div>
-    <div aria-hidden="true"><!-- Wrap the content under aria-hidden -->
+    <div aria-hidden="true" role="presentation"><!-- Wrap the content under aria-hidden -->
         <div id="schedule-tabs" class="schedule-period-module">
     		<ul class="nav nav-pills schedule-period-list">
             {{#each schedule_periods }}
@@ -24,7 +24,7 @@
             {{/each }}
     		</ul>
         </div>
-    
+		<h4 class="sr-only">Your {{ucfirst quarter}} {{year}} class schedule</h4>
         <div id="schedule_area">
         {{#if display_hours }}
         <!-- week view -->
@@ -123,7 +123,7 @@
         
         
         <!--Adding SR only final exam schedule-->
-        <h4 class="sr-only">Your {{ucfirst quarter}} {{year}} final exam</h4>
+        <h4 class="sr-only">Your {{ucfirst quarter}} {{year}} final exam schedule</h4>
         <div class="final_schedule_table sr-only">
     	<table>
     	    <thead>

--- a/myuw/templates/handlebars/card/schedule/visual.html
+++ b/myuw/templates/handlebars/card/schedule/visual.html
@@ -15,7 +15,7 @@
             <span class="shortTitle">{{summer_term}}</span>
             {{/if}}
     </h3>
-    <div><p class="sr-only"><a href="#CourseCards">Skip the visual schedule and go to course cards</a></p></div>
+    <div><p class="sr-only"><a href="/academics#academics_content_cards">Skip the visual schedule and go to course cards</a></p></div>
     <div aria-hidden="true" role="presentation"><!-- Wrap the content under aria-hidden -->
         <div id="schedule-tabs" class="schedule-period-module">
     		<ul class="nav nav-pills schedule-period-list">
@@ -24,7 +24,7 @@
             {{/each }}
     		</ul>
         </div>
-		<h4 class="sr-only">Your {{ucfirst quarter}} {{year}} class schedule</h4>
+		<h4 class="hidden">Your {{ucfirst quarter}} {{year}} class schedule</h4>
         <div id="schedule_area">
         {{#if display_hours }}
         <!-- week view -->
@@ -122,7 +122,7 @@
         <!-- end - if there are meetings with times to be arranged -->
         
         
-        <!--Adding SR only final exam schedule-->
+        <!--Adding SR only final exam schedule: Commenting out until gets fixed
         <h4 class="sr-only">Your {{ucfirst quarter}} {{year}} final exam schedule</h4>
         <div class="final_schedule_table sr-only">
     	<table>
@@ -155,7 +155,7 @@
     	        {{/each}}
     	    </tbody>
     	</table>
-        </div>
+        </div> -->
     </div>
 {{/if}}
 </div>


### PR DESCRIPTION
To fix the problem of the SR reads the empty final exam table before the visual schedule, the final exam content is moved after the visual schedule and h4 is applied.   
To address the limited browser/OS support of 'Aria-hidden=true', 'role=presentation' was added as an interim solution. 