### PR TITLE
removes migration preference creation

### DIFF
--- a/myuw/migrations/0009_migration_preference.py
+++ b/myuw/migrations/0009_migration_preference.py
@@ -13,18 +13,6 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.CreateModel(
-            name='MigrationPreference',
-            fields=[
-                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('display_onboard_message', models.BooleanField(default=True)),
-                ('display_pop_up', models.BooleanField(default=True)),
-                ('use_legacy_site', models.BooleanField(default=False)),
-            ],
-            options={
-                'db_table': 'migration_preference',
-            },
-        ),
         migrations.DeleteModel(
             name='CourseColor',
         ),


### PR DESCRIPTION
In reference to this error:

django.db.utils.OperationalError: (1050, \"Table 'migration_preference' already exists\")
", "path": "/data/myuw/builds/23da9ef0ecefb439df3eeadaffbbfb4f/bin:/usr/local/bin:/bin:/usr/bin", "state": "absent", "syspath": ["/var/tmp/ansible_EdDsfB", "/tmp/ansible_EdDsfB/ansible_modlib.zip", "/usr/lib/python2.6/site-packages/setuptools-0.6c11-py2.6.egg", "/usr/lib/python2.6/site-packages/virtualenv-1.7.2-py2.6.egg", "/usr/lib/python2.6/site-packages/hg_git-0.4.0-py2.6.egg", "/usr/lib/python2.6/site-packages/ordereddict-1.1-py2.6.egg", "/usr/lib/python2.6/site-packages/dulwich-0.9.0-py2.6-linux-x86_64.egg", "/usr/lib/python2.6/site-packages/requests-2.7.0-py2.6.egg", "/tmp/ansible_EdDsfB/ansible_modlib.zip", "/usr/lib64/python26.zip", "/usr/lib64/python2.6", "/usr/lib64/python2.6/plat-linux2", "/usr/lib64/python2.6/lib-tk", "/usr/lib64/python2.6/lib-old", "/usr/lib64/python2.6/lib-dynload", "/usr/lib64/python2.6/site-packages", "/usr/lib64/python2.6/site-packages/gtk-2.0", "/usr/lib/python2.6/site-packages", "/usr/lib/python2.6/site-packages/setuptools-0.6c11-py2.6.egg-info"]}
