### PR TITLE
hides no photo icon on class list from print view

### DIFF
--- a/myuw/static/css/photo_list.less
+++ b/myuw/static/css/photo_list.less
@@ -83,6 +83,10 @@
                 position: relative;
             }
 
+            .myuw-photo-list-content {
+                margin-top: 4px;
+            }
+
         }
 
     }
@@ -97,6 +101,10 @@
 
             li {
                 page-break-inside: avoid;
+            }
+
+            .myuw-photo-list-img-wrapper::before {
+                display: none;
             }
 
         }


### PR DESCRIPTION
Minor fix. 
- hides the icon used on class lists from the print view (saves ink!)
- adds a small bit of space between the student photo and the student's name.