### PR TITLE
Reorganizing dockerfile to minimize rebuilds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ ADD myuw/VERSION /app/myuw/
 RUN pip install mysqlclient
 ADD setup.py /app/
 ADD requirements.txt /app/
+RUN pip install -r requirements.txt
 ADD . /app/
 ENV DB sqlite3
 RUN django-admin.py startproject project .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,11 @@
 FROM python:2.7
+WORKDIR /app/
 ENV PYTHONUNBUFFERED 1
-WORKDIR /app
+ADD myuw/VERSION /app/myuw/
+RUN pip install mysqlclient
+ADD setup.py /app/
+ADD requirements.txt /app/
 ADD . /app/
 ENV DB sqlite3
-RUN pip install mysqlclient
-RUN pip install -r requirements.txt
 RUN django-admin.py startproject project .
 ADD docker /app/project/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     command: bash -c "pip install -r requirements.txt && python manage.py migrate && python manage.py runserver 0.0.0.0:8000"
     volumes:
       - ./myuw:/app/myuw
+      - ./docker:/app/myuw/project
     ports:
       - "8000:8000"
     environment:


### PR DESCRIPTION
By copying in setup.py and associated files and installing them before calling the ADD command we can avoid invalidating the cache of the layers beneath it. Basically whenever the hash of files that the ADD commands adds changes, Docker realizes that it has to re-do the container layer. By installing this first we can avoid issues like this.