### PR TITLE
Feature/travis cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 sudo: false
 language: python
 cache:
-  - pip
-  - bundler
+  directories:
+    - ~/.cache/pip
+    - node_modules
 services:
   - memcached
   - mysql
@@ -11,8 +12,8 @@ python:
   # - "3.6"
 env:
   matrix:
-    - DB=sqlite3
-    # - DB=mysql
+    - TEST=nodejs
+    - TEST=python
 before_script:
   - if [ "$DB" = "mysql" ] ; then mysql -u root -e 'create database myuw'; fi
   - if [ "$DB" = "mysql" ] ; then mysql -u root -e 'create user "myuw" identified by "my_pass"'; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,44 +1,42 @@
 sudo: false
-language: python
-cache:
-  directories:
-    - ~/.cache/pip
-    - node_modules
-services:
-  - memcached
-python:
-  - "2.7"
-  # - "3.6"
-env:
-  matrix:
-    - TEST=nodejs
-    - TEST=python
-before_script:
-#  - if [ "$DB" = "mysql" ] ; then mysql -u root -e 'create database myuw'; fi
-#  - if [ "$DB" = "mysql" ] ; then mysql -u root -e 'create user "myuw" identified by "my_pass"'; fi
-#  - if [ "$DB" = "mysql" ] ; then mysql -u root -e 'grant all on *.* to myuw'; fi
-  - if [ "$TEST" = "python" ]; then pip install MySQL-python; fi
-#  - if [ "$TRAVIS_PYTHON_VERSION" = "3.6" ] ; then pip install mysqlclient; fi
-
-  - if [ "$TEST" = "python" ]; then pip install coverage; fi
-  - if [ "$TEST" = "python" ]; then pip install python-coveralls; fi
-  - if [ "$TEST" = "python" ]; then pip install pycodestyle; fi
-  - if [ "$TEST" = "nodejs" ]; then npm install; fi
-  - if [ "$TEST" = "python" ]; then gem install coveralls-lcov; fi
-  - if [ "$TEST" = "python" ]; then cp travis-ci/manage.py manage.py; fi
-  - if [ "$TEST" = "python" ]; then python manage.py migrate; fi
-  - if [ "$TEST" = "nodejs" ]; then npm list; fi
-
-script:
-  - if [ "$TEST" = "python" ]; then pycodestyle myuw/ --exclude=migrations,myuw/static; fi
-  # Find </br> tags
-  - grep -re '<\s*/\s*br\s*>' myuw/templates/ ; test $? -eq 1
-  - grep -r 'static/' myuw/ | grep -v /test/ | grep -v washington.edu/static; test $? -eq 1
-  - if [ "$TEST" = "nodejs" ]; then npm run jshint myuw/static/js/  --verbose; fi
-  - if [ "$TEST" = "nodejs" ]; then npm run test; fi
-  - if [ "$TEST" = "python" ]; then FORCE_VIEW_TESTS=1 coverage run --source=myuw/ --omit=myuw/migrations/* manage.py test myuw; fi
- # - coveralls-lcov -v -n coverage/lcov.info > js-coverage.json
-after_script:
-#  - coveralls --merge=js-coverage.json
-   - if[ "$TEST" = "python" ]; then coveralls; fi
-notifications:
+matrix:
+  include:
+  - language: python
+    cache: pip
+    services:
+      - memcached
+    python:
+      - 2.7
+#     - "3.6"
+    before_script:
+#     - if [ "$DB" = "mysql" ] ; then mysql -u root -e 'create database myuw'; fi
+#     - if [ "$DB" = "mysql" ] ; then mysql -u root -e 'create user "myuw" identified by "my_pass"'; fi
+#     - if [ "$DB" = "mysql" ] ; then mysql -u root -e 'grant all on *.* to myuw'; fi
+      - pip install MySQL-python
+      - pip install coverage
+      - pip install python-coveralls
+      - pip install pycodestyle
+      - gem install coveralls-lcov
+      - cp travis-ci/manage.py manage.py
+      - python manage.py migrate
+    script:
+      - pycodestyle myuw/ --exclude=migrations,myuw/static
+      - coverage run --source=myuw/ --omit=myuw/migrations/* manage.py test myuw FORCE_VIEW_TESTS=1
+#     - coveralls-lcov -v -n coverage/lcov.info > js-coverage.json
+    after_script:
+#     - coveralls --merge=js-coverage.json
+      - coveralls
+# TODO: send coveralls to S3/lambda and merge
+  - language: node_js
+    cache:
+      directories:
+        - node_modules
+    before_script:
+      - npm install
+      - npm list
+    script:
+      - grep -re '<\s*/\s*br\s*>' myuw/templates/ ; test $? -eq 1
+      - grep -r 'static/' myuw/ | grep -v /test/ | grep -v washington.edu/static; test $? -eq 1
+      - npm run jshint myuw/static/js/  --verbose
+      - npm run test
+# TODO: send coveralls to S3/lambda and merge

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,27 +17,28 @@ before_script:
 #  - if [ "$DB" = "mysql" ] ; then mysql -u root -e 'create database myuw'; fi
 #  - if [ "$DB" = "mysql" ] ; then mysql -u root -e 'create user "myuw" identified by "my_pass"'; fi
 #  - if [ "$DB" = "mysql" ] ; then mysql -u root -e 'grant all on *.* to myuw'; fi
-  - if [ "$TRAVIS_PYTHON_VERSION" = "2.7" ] ; then pip install MySQL-python; fi
+  - if [ "$TEST" = "python" ]; then pip install MySQL-python; fi
 #  - if [ "$TRAVIS_PYTHON_VERSION" = "3.6" ] ; then pip install mysqlclient; fi
 
-  - pip install coverage
-  - pip install python-coveralls
-  - pip install pycodestyle
-  - npm install
-  - gem install coveralls-lcov
-  - cp travis-ci/manage.py manage.py
-  - python manage.py migrate
-  - npm list
+  - if [ "$TEST" = "python" ]; then pip install coverage; fi
+  - if [ "$TEST" = "python" ]; then pip install python-coveralls; fi
+  - if [ "$TEST" = "python" ]; then pip install pycodestyle; fi
+  - if [ "$TEST" = "nodejs" ]; then npm install; fi
+  - if [ "$TEST" = "python" ]; then gem install coveralls-lcov; fi
+  - if [ "$TEST" = "python" ]; then cp travis-ci/manage.py manage.py; fi
+  - if [ "$TEST" = "python" ]; then python manage.py migrate; fi
+  - if [ "$TEST" = "nodejs" ]; then npm list; fi
 
 script:
-  - pycodestyle myuw/ --exclude=migrations,myuw/static
+  - if [ "$TEST" = "python" ]; then pycodestyle myuw/ --exclude=migrations,myuw/static; fi
   # Find </br> tags
   - grep -re '<\s*/\s*br\s*>' myuw/templates/ ; test $? -eq 1
   - grep -r 'static/' myuw/ | grep -v /test/ | grep -v washington.edu/static; test $? -eq 1
-  - npm run jshint myuw/static/js/  --verbose
-  - npm run test
-  - FORCE_VIEW_TESTS=1 coverage run --source=myuw/ --omit=myuw/migrations/* manage.py test myuw
-  - coveralls-lcov -v -n coverage/lcov.info > js-coverage.json
+  - if [ "$TEST" = "nodejs" ]; then npm run jshint myuw/static/js/  --verbose; fi
+  - if [ "$TEST" = "nodejs" ]; then npm run test; fi
+  - if [ "$TEST" = "python" ]; then FORCE_VIEW_TESTS=1 coverage run --source=myuw/ --omit=myuw/migrations/* manage.py test myuw; fi
+ # - coveralls-lcov -v -n coverage/lcov.info > js-coverage.json
 after_script:
-  - coveralls --merge=js-coverage.json
+#  - coveralls --merge=js-coverage.json
+   - if[ "$TEST" = "python" ]; then coveralls; fi
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+addons:
+  artifacts:
+    s3_region: "us-west-2"
+
 sudo: false
 matrix:
   include:
@@ -12,21 +16,20 @@ matrix:
 #     - if [ "$DB" = "mysql" ] ; then mysql -u root -e 'create database myuw'; fi
 #     - if [ "$DB" = "mysql" ] ; then mysql -u root -e 'create user "myuw" identified by "my_pass"'; fi
 #     - if [ "$DB" = "mysql" ] ; then mysql -u root -e 'grant all on *.* to myuw'; fi
+      - mkdir ~/shared
       - pip install MySQL-python
+      - pip install awscli
       - pip install coverage
       - pip install python-coveralls
       - pip install pycodestyle
-      - gem install coveralls-lcov
       - cp travis-ci/manage.py manage.py
       - python manage.py migrate
     script:
       - pycodestyle myuw/ --exclude=migrations,myuw/static
-      - FORCE_VIEW_TESTS=1 coverage run --source=myuw/ --omit=myuw/migrations/* manage.py test myuw
-#     - coveralls-lcov -v -n coverage/lcov.info > js-coverage.json
+      - FORCE_VIEW_TESTS=1 COVERAGE_FILE=~/shared/.coverage coverage run --source=myuw/ --omit=myuw/migrations/* manage.py test myuw
     after_script:
-#     - coveralls --merge=js-coverage.json
-      - coveralls
-# TODO: send coveralls to S3/lambda and merge
+      - aws s3 sync ~/shared s3://$S3_BUCKET_NAME/$TRAVIS_BUILD_NUMBER
+
   - language: node_js
     node_js:
       - node
@@ -34,11 +37,32 @@ matrix:
       directories:
         - node_modules
     before_script:
+      - mkdir ~/shared
       - npm install
+      - gem install coveralls-lcov
       - npm list
+      - pip install --user awscli
     script:
       - grep -re '<\s*/\s*br\s*>' myuw/templates/ ; test $? -eq 1
       - grep -r 'static/' myuw/ | grep -v /test/ | grep -v washington.edu/static; test $? -eq 1
       - npm run jshint myuw/static/js/  --verbose
       - npm run test
-# TODO: send coveralls to S3/lambda and merge
+      - coveralls-lcov -v -n coverage/lcov.info > ~/shared/js-coverage.json
+    after_script:
+      - aws s3 sync ~/shared s3://$S3_BUCKET_NAME/$TRAVIS_BUILD_NUMBER
+
+  - stage: Deploy Coveralls
+    language: python
+    python:
+      - 2.7
+    install:
+      - pip install awscli
+      - pip install python-coveralls
+    script:
+      - aws s3 sync s3://$S3_BUCKET_NAME/$TRAVIS_BUILD_NUMBER ~/shared
+      - mv ~/shared/.coverage .coverage
+      - mv ~/shared/js-coverage.json js-coverage.json
+      - coveralls --merge=js-coverage.json
+      - aws s3 rm s3://$S3_BUCKET_NAME/$TRAVIS_BUILD_NUMBER
+
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ cache:
     - node_modules
 services:
   - memcached
-  - mysql
 python:
   - "2.7"
   # - "3.6"
@@ -15,11 +14,11 @@ env:
     - TEST=nodejs
     - TEST=python
 before_script:
-  - if [ "$DB" = "mysql" ] ; then mysql -u root -e 'create database myuw'; fi
-  - if [ "$DB" = "mysql" ] ; then mysql -u root -e 'create user "myuw" identified by "my_pass"'; fi
-  - if [ "$DB" = "mysql" ] ; then mysql -u root -e 'grant all on *.* to myuw'; fi
+#  - if [ "$DB" = "mysql" ] ; then mysql -u root -e 'create database myuw'; fi
+#  - if [ "$DB" = "mysql" ] ; then mysql -u root -e 'create user "myuw" identified by "my_pass"'; fi
+#  - if [ "$DB" = "mysql" ] ; then mysql -u root -e 'grant all on *.* to myuw'; fi
   - if [ "$TRAVIS_PYTHON_VERSION" = "2.7" ] ; then pip install MySQL-python; fi
-  - if [ "$TRAVIS_PYTHON_VERSION" = "3.6" ] ; then pip install mysqlclient; fi
+#  - if [ "$TRAVIS_PYTHON_VERSION" = "3.6" ] ; then pip install mysqlclient; fi
 
   - pip install coverage
   - pip install python-coveralls
@@ -36,7 +35,6 @@ script:
   - grep -re '<\s*/\s*br\s*>' myuw/templates/ ; test $? -eq 1
   - grep -r 'static/' myuw/ | grep -v /test/ | grep -v washington.edu/static; test $? -eq 1
   - npm run jshint myuw/static/js/  --verbose
-  - npm run mocha myuw/static/js/test/ --recursive
   - npm run test
   - FORCE_VIEW_TESTS=1 coverage run --source=myuw/ --omit=myuw/migrations/* manage.py test myuw
   - coveralls-lcov -v -n coverage/lcov.info > js-coverage.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,6 +63,6 @@ matrix:
       - mv ~/shared/.coverage .coverage
       - mv ~/shared/js-coverage.json js-coverage.json
       - coveralls --merge=js-coverage.json
-      - aws s3 rm s3://$S3_BUCKET_NAME/$TRAVIS_BUILD_NUMBER
+      - aws s3 rm --recursive s3://$S3_BUCKET_NAME/$TRAVIS_BUILD_NUMBER
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ addons:
   artifacts:
     s3_region: "us-west-2"
 
+dist: trusty
 sudo: false
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,11 +12,7 @@ matrix:
       - memcached
     python:
       - 2.7
-#     - "3.6"
     before_script:
-#     - if [ "$DB" = "mysql" ] ; then mysql -u root -e 'create database myuw'; fi
-#     - if [ "$DB" = "mysql" ] ; then mysql -u root -e 'create user "myuw" identified by "my_pass"'; fi
-#     - if [ "$DB" = "mysql" ] ; then mysql -u root -e 'grant all on *.* to myuw'; fi
       - mkdir ~/shared
       - pip install MySQL-python
       - pip install awscli

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,13 +21,15 @@ matrix:
       - python manage.py migrate
     script:
       - pycodestyle myuw/ --exclude=migrations,myuw/static
-      - coverage run --source=myuw/ --omit=myuw/migrations/* manage.py test myuw FORCE_VIEW_TESTS=1
+      - FORCE_VIEW_TESTS=1 coverage run --source=myuw/ --omit=myuw/migrations/* manage.py test myuw
 #     - coveralls-lcov -v -n coverage/lcov.info > js-coverage.json
     after_script:
 #     - coveralls --merge=js-coverage.json
       - coveralls
 # TODO: send coveralls to S3/lambda and merge
   - language: node_js
+    node_js:
+      - node
     cache:
       directories:
         - node_modules

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 sudo: false
 language: python
+cache:
+  - pip
+  - bundler
 services:
   - memcached
   - mysql
@@ -10,8 +13,6 @@ env:
   matrix:
     - DB=sqlite3
     # - DB=mysql
-install:
-  - pip install -r requirements.txt
 before_script:
   - if [ "$DB" = "mysql" ] ; then mysql -u root -e 'create database myuw'; fi
   - if [ "$DB" = "mysql" ] ; then mysql -u root -e 'create user "myuw" identified by "my_pass"'; fi

--- a/travis-ci/settings.py
+++ b/travis-ci/settings.py
@@ -89,24 +89,12 @@ WSGI_APPLICATION = 'travis-ci.wsgi.application'
 # Database
 # https://docs.djangoproject.com/en/1.7/ref/settings/#databases
 
-import os
-if os.environ['DB'] == "sqlite3":
-    DATABASES = {
-        'default': {
-            'ENGINE': 'django.db.backends.sqlite3',
-            'NAME': os.path.join(BASE_DIR, 'db.sqlite3'),
-        }
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': os.path.join(BASE_DIR, 'db.sqlite3'),
     }
-elif os.environ['DB'] == "mysql":
-    DATABASES = {
-        'default': {
-            'ENGINE': 'django.db.backends.mysql',
-            'NAME': 'myuw',
-            'USER': 'myuw',
-            'PASSWORD': 'my_pass',
-            'PORT': 3306,
-        }
-    }
+}
 
 # Internationalization
 # https://docs.djangoproject.com/en/1.7/topics/i18n/


### PR DESCRIPTION
Currently our travis setup does essentially the following:

1. Install python dependencies and run migrations
2. Install node.js dependencies
3. Run JS tests.
4. Lint JS
5. Run pycodestyle
6. Run django tests.

With this setup, we can achieve the following:

Python Container:
1. Install new python dependencies, refresh old ones from cache
2. Run migrations
3. Run pycodestyle
4. Run tests

Node.js container:
1. Install new node.js dependencies, refresh old ones from cache
2. Lint JS
3. Run Tests:

Coveralls container (after):
1. Combine coverage files from the two runs
2. Upload to coveralls