### PR TITLE
resolves MUWM-4350. sets overlay z-index to 100

### DIFF
--- a/myuw/static/css/cards.less
+++ b/myuw/static/css/cards.less
@@ -325,6 +325,7 @@
     .myuw-card-style-mixin;
     padding: 16px;
     max-width: 285px;
+    z-index: 100;
 
     & > .myuw-card-heading {
         margin-top: 0;


### PR DESCRIPTION
To test on personal build:

user: bill
class: ESS 102A spring '13
View photo class list and shrink the browser window to get the overlay to sit over the photos.

View Jira ticket for testing notes for my-test.