### PR TITLE
fixes spacing for academics page related links. resolves MUWM-3906

### DIFF
--- a/myuw/static/css/mobile.less
+++ b/myuw/static/css/mobile.less
@@ -775,16 +775,12 @@ label { font-weight: normal; margin-bottom: auto; }
 
     .profile-bio {
         padding: 0 0;
-	.profile-student-major {
-            text-align: left; padding-top:5px;
-	    .student-major-list {list-style: none;padding-left:0; margin-top:0;}
-	}
+    	.profile-student-major {
+                text-align: left; padding-top:5px;
+    	    .student-major-list {list-style: none;padding-left:0; margin-top:0;}
+    	}
     }
 
-    .aside-links {
-        padding-left: 16px;
-        ul { list-style-type: none; padding-left: 0; }
-    }
 
     // Move the action button out of the .card
     .card-actions-wrapper {

--- a/myuw/templates/handlebars/card/sidebar_links.html
+++ b/myuw/templates/handlebars/card/sidebar_links.html
@@ -1,11 +1,11 @@
 {% load templatetag_handlebars %}
 {% tplhandlebars "sidebar_link_card" %}
-    <div class="myuw-canvas aside-links" style="position:relative;">
+    <div class="myuw-canvas myuw-aside-links" style="position:relative;">
     {{#each link_data}}
         <h3 id="{{subcat_slug}}" class="myuw-canvas-title">{{subcategory}}</h3>
-        <ul class="category-links">
+        <ul class="unstyled-list">
         {{#each links}}
-            <li> <a href="{{ url }}" {{#if new_tab}}target="_blank"{{/if}}>{{title}}</a></li>
+            <li><a href="{{ url }}" {{#if new_tab}}target="_blank"{{/if}}>{{title}}</a></li>
         {{/each}}
         </ul>
     {{/each}}


### PR DESCRIPTION
Test on personal build with "javerage"
- View spacing of related links on Academics page. It should be the same as on the Profile, Quicklinks, Teaching page, etc.