### PR TITLE
resolves MUWM-4364

### DIFF
--- a/myuw/static/css/photo_list.less
+++ b/myuw/static/css/photo_list.less
@@ -2,11 +2,12 @@
 
 .myuw-photo-list {
 
+    margin-bottom: 11rem;
+
     @media @two-column {
         margin-top: 0;
         margin-left: -16px;
         margin-right: -16px;
-        margin-bottom: 16px;
         padding: 16px !important;
     }
 
@@ -32,7 +33,7 @@
             .form-inline[aria-hidden="true"] {
                 display: none;
             }
-            
+
             #sort_list {
                 display: inline-block;
                 width: auto;
@@ -103,7 +104,8 @@
     @media @print { border: none;
 
         .myuw-card { border: none; }
-        .myuw-photo-list-controls { display: none !important; }
+        .myuw-photo-list-controls,
+        .myuw-minicard-overlay { display: none !important; }
 
         ol.grid-view {
 


### PR DESCRIPTION
* Hides popup on the print view.
* Adds bottom margin to the class list so the popup can appear below the list.

Test with bill, ESS 102 A, Spring 2013. 
* Check the print view
* You'll need to narrow the browser window size to ensure the popup doesn't cover the students at the bottom.