### PR TITLE
Adding catchall logging and exception handling

### DIFF
--- a/myuw/event/section_status.py
+++ b/myuw/event/section_status.py
@@ -54,6 +54,6 @@ class SectionStatusProcessor(InnerMessageProcessor):
                         logger.error(msg)
                         raise SectionStatusProcessorException(msg)
         except Exception as e:
-            msg = "FAILED to process event" % str(json_data)
+            msg = "FAILED to process event with exception: %s" % str(e)
             logger.error(msg)
             raise SectionStatusProcessorException(msg)


### PR DESCRIPTION
I believe we want to have a catchall exception handler here so that misformated messages get redirected to the dead letter queue rather than breaking the polling process.