### PR TITLE
Resolve MUWM-4621

### DIFF
--- a/myuw/dao/canvas.py
+++ b/myuw/dao/canvas.py
@@ -60,7 +60,7 @@ def set_section_canvas_course_urls(canvas_active_enrollments, schedule,
             if not section.term.is_past(now):
                 log_exception(logger, "Possible registration data error",
                               traceback.format_exc(chain=False))
-            section.canvas_course_url = None
+            pass
 
 
 def get_canvas_course_from_section(sws_section):

--- a/myuw/resources/canvas/file/api/v1/users/sis_user_id%3A55555333366711D5BE060004AC494FFE/enrollments_state[]_active_type[]_StudentEnrollment
+++ b/myuw/resources/canvas/file/api/v1/users/sis_user_id%3A55555333366711D5BE060004AC494FFE/enrollments_state[]_active_type[]_StudentEnrollment
@@ -1,0 +1,40 @@
+[
+    {
+        "associated_user_id": null,
+        "course_id": 249652,
+        "course_section_id": 425707,
+        "sis_course_id": "2013-autumn-MUSEUM-700-A",
+        "sis_section_id": "2013-autumn-MUSEUM-700-A--",
+        "id": 15741787,
+        "limit_privileges_to_course_section": false,
+        "root_account_id": 83919,
+        "type": "StudentEnrollment",
+        "updated_at": "2013-12-18T21:41:03Z",
+        "user_id": 496168,
+        "enrollment_state": "active",
+        "role": "StudentEnrollment",
+        "last_activity_at": null,
+        "total_activity_time": 50,
+        "grades": {
+            "html_url": "https://test.edu/courses/249652/grades/496164",
+            "current_grade": null,
+            "current_score": 57.13,
+            "final_grade": null,
+            "final_score": 54.04,
+            "unposted_current_score": 57.13,
+            "unposted_current_grade": null,
+            "unposted_final_score": 54.04
+        },
+        "html_url": "https://test.edu/courses/249652/users/496164",
+        "user": {
+            "login_id": "jeos",
+            "sis_user_id": "55555333366711D5BE060004AC494FFE",
+            "sortable_name": "STUDENT, EOS AVERAGE",
+            "short_name": "JAMES EOS STUDENT",
+            "id": 496168,
+            "name": "JAMES EOS STUDENT",
+            "sis_login_id": "jeos"
+        }
+    }
+
+]

--- a/myuw/test/dao/test_canvas.py
+++ b/myuw/test/dao/test_canvas.py
@@ -23,7 +23,7 @@ class TestCanvas(TestCase):
         self.assertIsNotNone(req.canvas_act_enrollments)
 
         set_section_canvas_course_urls(canvas_active_enrollments,
-                                       schedule)
+                                       schedule, req)
         section1 = schedule.sections[0]
         self.assertEquals(section1.section_label(),
                           "2013,spring,PHYS,121/A")

--- a/myuw/test/dao/test_canvas.py
+++ b/myuw/test/dao/test_canvas.py
@@ -64,7 +64,8 @@ class TestCanvas(TestCase):
         self.assertIsNotNone(req.canvas_act_enrollments)
         set_section_canvas_course_urls(canvas_active_enrollments,
                                        schedule, req)
-        self.assertIsNone(schedule.sections[0].canvas_course_url)
+        with self.assertRaises(AttributeError):
+            a = schedule.sections[0].canvas_course_url
 
     def test_get_canvas_course_url(self):
         person = Person()

--- a/myuw/test/dao/test_canvas.py
+++ b/myuw/test/dao/test_canvas.py
@@ -3,7 +3,6 @@ from myuw.dao.canvas import (
     get_canvas_active_enrollments, set_section_canvas_course_urls,
     get_canvas_course_from_section,
     get_canvas_course_url, sws_section_label, get_viewable_course_sections)
-from uw_sws.exceptions import InvalidCanvasIndependentStudyCourse
 from uw_sws.models import Person
 from uw_sws.section import get_section_by_label
 from myuw.dao.term import get_current_quarter
@@ -63,10 +62,9 @@ class TestCanvas(TestCase):
         schedule = get_schedule_by_term(req, get_current_quarter(req))
         canvas_active_enrollments = get_canvas_active_enrollments(req)
         self.assertIsNotNone(req.canvas_act_enrollments)
-        self.assertRaises(InvalidCanvasIndependentStudyCourse,
-                          set_section_canvas_course_urls,
-                          canvas_active_enrollments,
-                          schedule, req)
+        set_section_canvas_course_urls(canvas_active_enrollments,
+                                       schedule, req)
+        self.assertIsNone(schedule.sections[0].canvas_course_url)
 
     def test_get_canvas_course_url(self):
         person = Person()

--- a/myuw/test/dao/test_canvas.py
+++ b/myuw/test/dao/test_canvas.py
@@ -68,7 +68,6 @@ class TestCanvas(TestCase):
                           canvas_active_enrollments,
                           schedule, req)
 
-
     def test_get_canvas_course_url(self):
         person = Person()
         person.uwnetid = "javerage"

--- a/myuw/views/api/base_schedule.py
+++ b/myuw/views/api/base_schedule.py
@@ -84,7 +84,7 @@ def load_schedule(request, schedule, summer_term=""):
     if len(schedule.sections):
         try:
             set_section_canvas_course_urls(
-                get_canvas_active_enrollments(request), schedule)
+                get_canvas_active_enrollments(request), schedule, request)
         except Exception:
             log_exception(logger, 'get_canvas_active_enrollments',
                           traceback.format_exc(chain=False))

--- a/myuw/views/api/base_schedule.py
+++ b/myuw/views/api/base_schedule.py
@@ -1,6 +1,5 @@
 import logging
 import traceback
-from myuw.util.thread import Thread
 from operator import itemgetter
 from restclients_core.exceptions import InvalidNetID
 from myuw.dao.building import get_buildings_by_schedule


### PR DESCRIPTION
https://jira.cac.washington.edu/browse/MUWM-4621
This update is to handle the InvalidCanvasIndependentStudyCourse and reduce unnecessary logging of the error.

The independent_study_instructor_regid is None as the instructor of independent study section of any PRIOR quarter is NOT in SWS.  The MyUW schedule object contains the last quarter sections to display grades.  More details is in the Jira link above.

On my-test.