### PR TITLE
Temporary fix to django compressor

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,8 +27,7 @@ FROM pre-container as app-container
 
 COPY --chown=acait:acait --from=node-bundler /static /static
 
-RUN . /app/bin/activate && python manage.py collectstatic --noinput &&\
-    python manage.py compress -f
+RUN . /app/bin/activate && python manage.py collectstatic --noinput
 
 FROM acait/django-test-container:1.0.35 as app-test-container
 


### PR DESCRIPTION
The last compress use is removed from blti.
https://github.com/uw-it-aca/django-blti/commit/c12d1414c76830329f8acb4de838cb5dc64f4fd7

This is a temporary fix to make the container build without errors.

Eventually the static files need to server differently or the webpack storage file need to different