### PR TITLE
Adds mobileOnly logic to sidebar links (panel) for responsive UI.

### DIFF
--- a/myuw/static/vue/components/_templates/panel.vue
+++ b/myuw/static/vue/components/_templates/panel.vue
@@ -1,6 +1,6 @@
 <template>
   <div v-if="(mobileOnly && $mq === 'mobile') || !mobileOnly">
-    <div v-if="loaded" class="">
+    <div v-if="loaded" :class="[$mq === 'mobile' ? 'px-3' : 'px-0']">
       <slot name="panel-body" />
     </div>
     <div v-else>

--- a/myuw/static/vue/components/academics/sidebar-links.vue
+++ b/myuw/static/vue/components/academics/sidebar-links.vue
@@ -1,6 +1,6 @@
 <template>
-  <panel
-    :loaded="isReady"
+  <uw-panel
+    :loaded="isReady" :mobile-only="mobileOnly"
   >
     <template #panel-body>
       <div v-for="linkCategory in linkData" :key="linkCategory.subcat_slug">
@@ -19,7 +19,7 @@
         </ul>
       </div>
     </template>
-  </panel>
+  </uw-panel>
 </template>
 
 <script>
@@ -28,7 +28,13 @@ import Panel from '../_templates/panel.vue';
 
 export default {
   components: {
-    'panel': Panel,
+    'uw-panel': Panel,
+  },
+  props: {
+    mobileOnly: {
+      type: Boolean,
+      default: false,
+    },
   },
   data: function() {
     return {

--- a/myuw/templates/academics.html
+++ b/myuw/templates/academics.html
@@ -23,7 +23,7 @@
       <myuw-grad-committee></myuw-grad-committee>
       <myuw-future-quarter-cards highlighted></myuw-future-quarter-cards>
       <myuw-future-quarter-cards></myuw-future-quarter-cards>
-
+      <myuw-sidebar-links mobile-only></myuw-sidebar-links>
     </b-col>
   </template>
   <!-- MARK: #secondary template (column 2, table/desktop) -->


### PR DESCRIPTION
Found this bug with Academics sidebar links. It should be displayed below the cards on mobile... and move to the sidebar on tablet/desktop.