### PR TITLE
Updates mixins call with parens.

### DIFF
--- a/myuw/static/css/cards.less
+++ b/myuw/static/css/cards.less
@@ -13,7 +13,7 @@
 
 .myuw-card {
 
-    .myuw-card-style-mixin;
+    .myuw-card-style-mixin();
     margin-top: 0;
     margin-left: -16px;
     margin-right: -16px;
@@ -328,7 +328,7 @@
 
 
 .myuw-minicard-overlay {
-    .myuw-card-style-mixin;
+    .myuw-card-style-mixin();
     padding: 16px;
     max-width: 285px;
     z-index: 100;

--- a/myuw/static/css/resources.less
+++ b/myuw/static/css/resources.less
@@ -99,7 +99,7 @@ ol.resources-toc {
         }
     }
     .myuw-canvas:hover {
-        .myuw-card-style-mixin;
+        .myuw-card-style-mixin();
 
         border-left: none;
         border-right: none;


### PR DESCRIPTION
This fixes the failing Develop build caused by the Less version upgrade and previous mixins call without parens. Parens have been required and are now enforced in new versions.