### PR TITLE
changing card order

### DIFF
--- a/myuw/static/vue/components/home/quicklinks/covid-links.vue
+++ b/myuw/static/vue/components/home/quicklinks/covid-links.vue
@@ -4,13 +4,13 @@
       <h3 class="h6">
         UW Coronavirus
       </h3>
-      <ul v-if="links.student" class="list-unstyled myuw-text-md">
+      <ul class="list-unstyled myuw-text-md">
         <li class="mb-1">
-          <a href="https://www.washington.edu/coronavirus/autumnquarter/">
-            Autumn Quarter FAQs
+          <a href="https://www.washington.edu/coronavirus/">
+            UW Coronavirus Home
           </a>
         </li>
-        <li class="mb-1">
+        <li v-if="links.student" class="mb-1">
           <a href="https://www.washington.edu/coronavirus/students/">
             Resources for Students
           </a>
@@ -35,16 +35,9 @@
             Student Wellness Check-In
           </a>
         </li>
-        <li class="mb-1">
+        <li v-if="links.student" class="mb-1">
           <a href="https://www.washington.edu/counseling/covid-19/">
             Coping with COVID-19 Stress
-          </a>
-        </li>
-      </ul>
-      <ul v-else class="list-unstyled mb-0 myuw-text-md">
-        <li class="mb-1">
-          <a href="https://www.washington.edu/coronavirus/">
-            UW Coronavirus Home
           </a>
         </li>
       </ul>

--- a/myuw/templates/accounts.html
+++ b/myuw/templates/accounts.html
@@ -12,8 +12,8 @@
     <b-col md="12" class="px-0">
       <myuw-tuition-fees></myuw-tuition-fees>
       <myuw-medicine-account></myuw-medicine-account>
-      <myuw-husky></myuw-husky>
       <myuw-hfs-sea></myuw-hfs-sea>
+      <myuw-husky></myuw-husky>
       <myuw-hr-payroll></myuw-hr-payroll>
       <myuw-library></myuw-library>
       <myuw-upass></myuw-upass>
@@ -26,8 +26,8 @@
       <b-card-group columns class="myuw-column-count-2">
         <myuw-tuition-fees></myuw-tuition-fees>
         <myuw-medicine-account></myuw-medicine-account>
-        <myuw-husky></myuw-husky>
         <myuw-hfs-sea></myuw-hfs-sea>
+        <myuw-husky></myuw-husky>
         <myuw-hr-payroll></myuw-hr-payroll>
         <myuw-library></myuw-library>
         <myuw-upass></myuw-upass>


### PR DESCRIPTION
fixes https://jira.cac.washington.edu/browse/MUWM-4959

Changed order so Husky card comes after HFS card in DOM; in some/most cases for students this will display it in the top-right position of the page, on a desktop. 