### PR TITLE
Add persistent_message on support page (#2749)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,9 @@ FROM app-prewebpack-container as app-container
 
 ADD --chown=acait:acait . /app/
 ADD --chown=acait:acait docker/ project/
+ADD --chown=acait:acait docker/app_start.sh /scripts
+RUN chmod u+x /scripts/app_start.sh
+
 COPY --chown=acait:acait --from=node-bundler /app/myuw/static /app/myuw/static
 
 RUN . /app/bin/activate && python manage.py collectstatic --noinput

--- a/docker/app_start.sh
+++ b/docker/app_start.sh
@@ -1,0 +1,7 @@
+if [ "$ENV"  = "localdev" ]
+then
+
+  python manage.py migrate
+  python manage.py loaddata persistent_messages.json
+
+fi

--- a/docker/settings.py
+++ b/docker/settings.py
@@ -17,6 +17,7 @@ INSTALLED_APPS += [
     'django_client_logger',
     'django_user_agents',
     'hx_toolkit',
+    'persistent_message',
     'rc_django',
     'userservice',
     'supporttools',
@@ -118,9 +119,13 @@ SUPPORTTOOLS_PARENT_APP_URL = "/"
 USERSERVICE_VALIDATION_MODULE = "myuw.authorization.validate_netid"
 USERSERVICE_OVERRIDE_AUTH_MODULE = "myuw.authorization.can_override_user"
 RESTCLIENTS_ADMIN_AUTH_MODULE = "myuw.authorization.can_proxy_restclient"
+PERSISTENT_MESSAGE_AUTH_MODULE = 'myuw.authorization.is_myuw_admin'
 
 COMPRESS_ENABLED = True
 COMPRESS_OFFLINE = os.getenv("COMPRESSOR_ENABLED", "True") == "True"
+COMPRESS_OFFLINE_CONTEXT = {
+    'wrapper_template': 'persistent_message/manage_wrapper.html',
+}
 
 if os.getenv("COMPRESSOR_ENABLED", "True") == "False":
     COMPRESS_ENABLED = False

--- a/docker/urls.py
+++ b/docker/urls.py
@@ -8,6 +8,7 @@ from django.urls import include, re_path
 urlpatterns += [
     re_path(r'^support', include('userservice.urls')),
     re_path(r'^restclients/', include('rc_django.urls')),
+    re_path(r'^persistent_message/', include('persistent_message.urls')),
     re_path(r'^logging/', include('django_client_logger.urls')),
     re_path(r'^', include('myuw.urls')),
 ]

--- a/myuw/dao/persistent_messages.py
+++ b/myuw/dao/persistent_messages.py
@@ -1,0 +1,145 @@
+# Copyright 2022 UW-IT, University of Washington
+# SPDX-License-Identifier: Apache-2.0
+
+import logging
+from persistent_message.models import Message
+from myuw.dao.affiliation import get_all_affiliations
+from myuw.dao.gws import is_effective_member
+from myuw.dao.term import get_comparison_datetime_with_tz
+
+logger = logging.getLogger(__name__)
+
+
+class BannerMessage(object):
+
+    def __init__(self, request):
+        self.request = request
+        self.affiliations = get_all_affiliations(request)
+        self.now = get_comparison_datetime_with_tz(self.request)
+
+    def get_message_json(self):
+        user_msgs = []
+        for msg in Message.objects.all().order_by('begins'):
+            if msg.is_active(self.now) and self._matched_with_affi(msg):
+                user_msgs.append(self._to_json(msg))
+        return user_msgs
+
+    def _matched_with_affi(self, msg):
+        tags = msg.tags.all()
+
+        if (len(tags) == 0 or  # for everyone
+                self._for_alumni(tags) or
+                self._for_applicant(tags)):
+            return True
+
+        if (self._campus_neutral(tags) and
+                (self._employee_affiliation_matched(tags) or
+                 self._student_affiliation_matched(tags))):
+            return True
+
+        if self._student_affiliation_matched(tags):
+            if self._is_stud_campus_matched(tags):
+                return True
+
+        if self._employee_affiliation_matched(tags):
+            if self._is_employee_campus_matched(tags):
+                return True
+        return False
+
+    def _to_json(self, msg, include_tags=False):
+        json_data = {
+            'id': msg.pk,
+            'content': msg.content,
+            'level': msg.level,
+            'level_name': msg.get_level_display(),
+            'start': msg.begins.isoformat() if (
+                msg.begins is not None) else None,
+            'end': msg.expires.isoformat() if (
+                msg.expires is not None) else None
+        }
+        if include_tags:
+            for tag in msg.tags.all():
+                json_data[tag.name] = True
+        return json_data
+
+    def __match(self, msg_tags, tag_name, tag_group_name):
+        for tag in msg_tags:
+            if tag.name == tag_name and tag.group.name == tag_group_name:
+                return True
+        return False
+
+    def _match_campuses(self, msg_tags, tag_name):
+        return self.__match(msg_tags, tag_name, 'Campuses')
+
+    def _match_affiliation(self, msg_tags, tag_name):
+        return self.__match(msg_tags, tag_name, 'Affiliations')
+
+    def _for_bothell(self, msg_tags):
+        return self._match_campuses(msg_tags, 'bothell')
+
+    def _for_seattle(self, msg_tags):
+        return self._match_campuses(msg_tags, 'seattle')
+
+    def _for_tacoma(self, msg_tags):
+        return self._match_campuses(msg_tags, 'tacoma')
+
+    def _campus_neutral(self, msg_tags):
+        return not (
+            self._for_bothell(msg_tags) or
+            self._for_seattle(msg_tags) or
+            self._for_tacoma(msg_tags))
+
+    def _for_alumni(self, msg_tags):
+        return (
+            self._campus_neutral(msg_tags) and
+            self._match_affiliation(msg_tags, 'alumni') and
+            self.affiliations["alumni"])
+
+    def _for_applicant(self, msg_tags):
+        return (
+            self._campus_neutral(msg_tags) and
+            self._match_affiliation(msg_tags, 'applicant') and
+            self.affiliations["applicant"])
+
+    def _is_stud_campus_matched(self, msg_tags):
+        return (
+            self._campus_neutral(msg_tags) or
+            self._for_seattle(msg_tags) and self.affiliations['seattle'] or
+            self._for_bothell(msg_tags) and self.affiliations['bothell'] or
+            self._for_tacoma(msg_tags) and self.affiliations['tacoma'])
+
+    def _is_employee_campus_matched(self, msg_tags):
+        return (
+            self._campus_neutral(msg_tags) or
+            self._for_seattle(msg_tags) and
+            self.affiliations['official_seattle'] or
+            self._for_bothell(msg_tags) and
+            self.affiliations['official_bothell'] or
+            self._for_tacoma(msg_tags) and
+            self.affiliations['official_tacoma'])
+
+    def _student_affiliation_matched(self, msg_tags):
+        return (
+            self._match_affiliation(msg_tags, 'grad-student') and
+            self.affiliations["grad"] or
+            self._match_affiliation(msg_tags, 'gradC2') and
+            self.affiliations["grad_c2"] or
+            self._match_affiliation(msg_tags, 'intl-student') and
+            self.affiliations["intl_stud"] or
+            self._match_affiliation(msg_tags, 'undergraduate') and
+            self.affiliations["undergrad"] or
+            self._match_affiliation(msg_tags, 'undergraduateC2') and
+            self.affiliations["undergrad_c2"] or
+            self._match_affiliation(msg_tags, 'student-employee') and
+            self.affiliations["stud_employee"])
+
+    def _employee_affiliation_matched(self, msg_tags):
+        return (
+            self._match_affiliation(msg_tags, 'clinician') and
+            self.affiliations["clinician"] or
+            self._match_affiliation(msg_tags, 'faculty') and
+            self.affiliations["faculty"] or
+            self._match_affiliation(msg_tags, 'instructor') and
+            self.affiliations["instructor"] or
+            self._match_affiliation(msg_tags, 'staff-employee') and
+            self.affiliations["staff-employee"])

--- a/myuw/fixtures/persistent_messages.json
+++ b/myuw/fixtures/persistent_messages.json
@@ -1,0 +1,192 @@
+[
+  {
+    "model": "persistent_message.taggroup",
+    "pk": 1,
+    "fields": {
+      "name": "Campuses"
+    }
+  },
+  {
+    "model": "persistent_message.tag",
+    "pk": 1,
+    "fields": {
+      "name": "seattle",
+      "group": 1
+    }
+  },
+  {
+    "model": "persistent_message.tag",
+    "pk": 2,
+    "fields": {
+      "name": "bothell",
+      "group": 1
+    }
+  },
+  {
+    "model": "persistent_message.tag",
+    "pk": 3,
+    "fields": {
+      "name": "tacoma",
+      "group": 1
+    }
+  },
+  {
+    "model": "persistent_message.taggroup",
+    "pk": 2,
+    "fields": {
+      "name": "Affiliations"
+    }
+  },
+  {
+    "model": "persistent_message.tag",
+    "pk": 10,
+    "fields": {
+      "name": "alumni",
+      "group": 2
+    }
+  },
+  {
+    "model": "persistent_message.tag",
+    "pk": 11,
+    "fields": {
+      "name": "applicant",
+      "group": 2
+    }
+  },
+  {
+    "model": "persistent_message.tag",
+    "pk": 12,
+    "fields": {
+      "name": "grad-student",
+      "group": 2
+    }
+  },
+  {
+    "model": "persistent_message.tag",
+    "pk": 13,
+    "fields": {
+      "name": "undergraduate",
+      "group": 2
+    }
+  },
+  {
+    "model": "persistent_message.tag",
+    "pk": 14,
+    "fields": {
+      "name": "gradC2",
+      "group": 2
+    }
+  },
+  {
+    "model": "persistent_message.tag",
+    "pk": 15,
+    "fields": {
+      "name": "undergraduateC2",
+      "group": 2
+    }
+  },
+  {
+    "model": "persistent_message.tag",
+    "pk": 16,
+    "fields": {
+      "name": "intl-student",
+      "group": 2
+    }
+  },
+  {
+    "model": "persistent_message.tag",
+    "pk": 21,
+    "fields": {
+      "name": "clinician",
+      "group": 2
+    }
+  },
+  {
+    "model": "persistent_message.tag",
+    "pk": 22,
+    "fields": {
+      "name": "faculty",
+      "group": 2
+    }
+  },
+  {
+    "model": "persistent_message.tag",
+    "pk": 23,
+    "fields": {
+      "name": "instructor",
+      "group": 2
+    }
+  },
+  {
+    "model": "persistent_message.tag",
+    "pk": 24,
+    "fields": {
+      "name": "staff-employee",
+      "group": 2
+    }
+  },
+  {
+    "model": "persistent_message.tag",
+    "pk": 25,
+    "fields": {
+      "name": "student-employee",
+      "group": 2
+    }
+  },
+  {
+    "model": "persistent_message.message",
+    "pk": 1,
+    "fields": {
+      "content": "Planned maintenance of the student information system will disrupt display of content on MyUW from 8:00 a.m. to 12 p.m. PST on <span class='date'>Sunday, Feb 10th</span>. Some data may not be current or may be unavailable. Content for those applying to the UW will be unavailable. Please check back after 12:00 p.m. PST to view your content.",
+      "level": 20,
+      "begins": "2013-04-01T00:00:01-07:00",
+      "expires": "2013-04-07T10:10:10+00:00",
+      "created": "2013-04-01T00:00:01-07:00",
+      "modified": "2013-04-02T10:10:10+00:00",
+      "modified_by": "bill",
+      "tags": []
+    }
+  },
+  {
+    "model": "persistent_message.message",
+    "pk": 2,
+    "fields": {
+      "content": "<strong>MyUW mobile app</strong> is now available! Get it at the <a href='https://apps.apple.com/us/app/myuw/id1521514519'>Apple App Store</a> and on <a href='https://play.google.com/store/apps/details?id=edu.uw.myuw_android&hl=en_US&gl=US'>Google Play</a>",
+      "level": 25,
+      "begins": "2013-04-08T00:00:01-07:00",
+      "expires": "2013-04-18T10:10:10+00:00",
+      "created": "2013-04-08T00:00:01-07:00",
+      "modified": "2013-04-09T10:10:10+00:00",
+      "modified_by": "bill",
+      "tags": []
+    }
+  },
+  {
+    "model": "persistent_message.message",
+    "pk": 3,
+    "fields": {
+      "content": "Users are experiencing failed logins to UW web services, including ..., due to heavy load. Trying again often fixes the issue. See <a href='https://eoutage.uw.edu' class='external-link'>eOutage website</a> for more information.",
+      "level": 30,
+      "begins": "2013-04-15T00:00:01-07:00",
+      "expires": "2013-04-21T10:10:10+00:00",
+      "created": "2013-04-15T00:00:01-07:00",
+      "modified": "2013-04-16T10:10:10+00:00",
+      "modified_by": "bill",
+      "tags": []
+    }
+  },
+  {
+    "model": "persistent_message.message",
+    "pk": 4,
+    "fields": {
+      "content": "MyUW is incorrectly displaying tuition balances for some students. Our engineers are working to resolve this issue. Your tuition balance will be correctly displayed in the tuition payment system.",
+      "level": 40,
+      "begins": "2013-04-22T00:00:01-07:00",
+      "expires": "2013-04-28T10:10:10+00:00",
+      "created": "2013-04-22T00:00:01-07:00",
+      "modified": "2013-04-23T10:10:10+00:00",
+      "modified_by": "bill",
+      "tags": []
+    }
+  }
+]

--- a/myuw/templates/base.html
+++ b/myuw/templates/base.html
@@ -63,6 +63,7 @@
     {{ user|json_script:'user' }}
     {{ disable_actions|json_script:'disable_actions' }}
     {{ banner_messages|json_script:'banner_messages' }}
+    {{ persistent_messages|json_script:'persistent_messages' }}
     {{ display_onboard_message|json_script:'display_onboard_message' }}
     {{ display_pop_up|json_script:'display_pop_up' }}
     {{ card_display_dates|json_script:'card_display_dates' }}

--- a/myuw/templates/supporttools/custom_sidebar_links.html
+++ b/myuw/templates/supporttools/custom_sidebar_links.html
@@ -19,6 +19,14 @@
 {% if is_myuw_admin %}
     <h3>Content Management</h3>
     <ul>
+        {% url 'manage_persistent_messages' as manage_messages_url %}
+        {% if manage_messages_url %}
+            <li>
+                <a href="{{ manage_messages_url }}">
+                    {{ persistent_message_link|default:"Persistent Messages" }}
+                </a>
+            </li>
+        {% endif %}
         <li><a href="{% url 'myuw_manage_messages' %}">Banner Messages</a></li>
         <li><a href="{% url 'myuw_popular_links' %}">Popular Links</a></li>
         <li><a href="{% url 'myuw_manage_notices' %}">MyUW Notices</a></li>

--- a/myuw/test/api/test_persistent_messages.py
+++ b/myuw/test/api/test_persistent_messages.py
@@ -1,0 +1,27 @@
+# Copyright 2022 UW-IT, University of Washington
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+from persistent_message.models import Message
+from myuw.test.api import MyuwApiTest, require_url
+
+
+@require_url('myuw_banner_message')
+class PersistentMessageAPITest(MyuwApiTest):
+    fixtures = ['persistent_messages.json']
+
+    def get_response(self):
+        return self.get_response_by_reverse('myuw_banner_message')
+
+    def test_javerage(self):
+        self.set_user('javerage')
+        response = self.get_response()
+        self.assertEquals(response.status_code, 200)
+        data = json.loads(response.content)
+        self.assertEquals(len(data), 2)
+
+        Message.objects.all().delete()
+        response = self.get_response()
+        self.assertEquals(response.status_code, 200)
+        data = json.loads(response.content)
+        self.assertEquals(len(data), 0)

--- a/myuw/test/dao/test_persistent_messages.py
+++ b/myuw/test/dao/test_persistent_messages.py
@@ -1,0 +1,101 @@
+# Copyright 2022 UW-IT, University of Washington
+# SPDX-License-Identifier: Apache-2.0
+
+from datetime import timedelta
+from persistent_message.models import Message, Tag
+from django.test import TransactionTestCase, override_settings
+from myuw.dao.term import get_comparison_datetime_with_tz
+from myuw.dao.persistent_messages import BannerMessage
+from myuw.test import (get_request_with_user, get_request_with_date)
+
+
+def setup_db(req):
+    msg = Message()
+    msg.content = 'Hello World!'
+    msg.begins = (
+        get_comparison_datetime_with_tz(req) - timedelta(days=1))
+    msg.save()
+    return msg
+
+
+def set_tags(msg, tag_names):
+    tags = []
+    for tag in tag_names:
+        msg.tags.add(Tag.objects.get(name=tag))
+    msg.save()
+    return msg
+
+
+class PersistentMessageDAOTest(TransactionTestCase):
+    fixtures = ['persistent_messages.json']
+
+    def test_tags(self):
+        tags = Tag.objects.all()
+        self.assertEqual(len(tags), 15)
+
+    def test_get_message_for_all(self):
+        req = get_request_with_user('none')
+        bm = BannerMessage(req)
+        data = bm.get_message_json()
+        self.assertEqual(len(data), 2)
+        self.assertEqual(data[0]["start"], "2013-04-08T07:00:01+00:00")
+        self.assertEqual(data[1]["start"], "2013-04-15T07:00:01+00:00")
+
+    def test_get_message_no_match(self):
+        req = get_request_with_user('seagrad')
+        Message.objects.all().delete()
+        msg = setup_db(req)
+        msg = set_tags(msg, ['bothell'])
+        bm = BannerMessage(req)
+        self.assertEqual(len(bm.get_message_json()), 0)
+
+    def test_get_message_for_undergraduate(self):
+        req = get_request_with_user('javerage')
+        bm = BannerMessage(req)
+        msg = setup_db(req)
+        msg = set_tags(msg, ['seattle', 'undergraduate'])
+        json_content = bm._to_json(msg, True)
+        self.assertEqual(json_content['content'], 'Hello World!')
+        self.assertEqual(json_content['level_name'], 'Info')
+        self.assertEqual(json_content['start'], '2013-04-14T00:00:01-07:00')
+        self.assertIsNone(json_content['end'])
+        self.assertTrue(json_content['seattle'])
+        self.assertTrue(json_content['undergraduate'])
+
+        tags = msg.tags.all()
+        self.assertTrue(bm._is_stud_campus_matched(tags))
+        self.assertTrue(bm._student_affiliation_matched(tags))
+        self.assertEqual(len(bm.get_message_json()), 3)
+
+    def test_get_message_for_faculty(self):
+        req = get_request_with_user('bill')
+        bm = BannerMessage(req)
+        msg = setup_db(req)
+        msg = set_tags(msg, ['faculty'])
+        tags = msg.tags.all()
+        self.assertTrue(bm._employee_affiliation_matched(tags))
+        self.assertEqual(len(bm.get_message_json()), 3)
+
+        msg = set_tags(msg, ['seattle'])
+        tags = msg.tags.all()
+        self.assertTrue(bm._is_employee_campus_matched(tags))
+        self.assertEqual(len(bm.get_message_json()), 3)
+
+    def test_get_message_for_alumni(self):
+        req = get_request_with_user('jalum')
+        bm = BannerMessage(req)
+        msg = setup_db(req)
+        msg = set_tags(msg, ['alumni'])
+        tags = msg.tags.all()
+        self.assertTrue(bm._campus_neutral(tags))
+        self.assertTrue(bm._for_alumni(tags))
+        self.assertEqual(len(bm.get_message_json()), 3)
+
+    def test_get_message_for_applicant(self):
+        req = get_request_with_user('japplicant')
+        bm = BannerMessage(req)
+        msg = setup_db(req)
+        msg = set_tags(msg, ['applicant'])
+        tags = msg.tags.all()
+        self.assertTrue(bm._for_applicant(tags))
+        self.assertEqual(len(bm.get_message_json()), 3)

--- a/myuw/test/views/test_page.py
+++ b/myuw/test/views/test_page.py
@@ -111,6 +111,7 @@ class TestPageMethods(MyuwApiTest):
             self.assertEquals(response.context["disable_actions"], False)
             self.assertIsNotNone(response.context["card_display_dates"])
             self.assertIsNotNone(response.context["user"]["affiliations"])
+            self.assertIsNotNone(response.context["persistent_messages"])
             self.assertEquals(response.context["user"]['email_forward_url'],
                               'http://alpine.washington.edu')
             self.assertIsNone(response.context['google_search_key'])

--- a/myuw/urls.py
+++ b/myuw/urls.py
@@ -30,6 +30,7 @@ from myuw.views.rest_search import MyUWRestSearchView
 from myuw.views.api.affiliation import Affiliation
 from myuw.views.api.applications import Applications
 from myuw.views.api.banner_message import CloseBannerMsg, TurnOffPopup
+from myuw.views.api.persistent_messages import BannerMessage
 from myuw.views.api.current_schedule import StudClasScheCurQuar
 from myuw.views.api.instructor_section import (InstSectionDetails,
                                                LTIInstSectionDetails)
@@ -98,6 +99,9 @@ urlpatterns += [
     re_path(r'api/v1/close_banner_message',
             CloseBannerMsg.as_view(),
             name="myuw_close_banner_message"),
+    re_path(r'api/v1/banner_message/$',
+            BannerMessage.as_view(),
+            name="myuw_banner_message"),
     re_path(r'api/v1/turn_off_tour_popup',
             TurnOffPopup.as_view(),
             name="myuw_turn_off_tour_popup"),

--- a/myuw/views/api/persistent_messages.py
+++ b/myuw/views/api/persistent_messages.py
@@ -1,0 +1,27 @@
+# Copyright 2022 UW-IT, University of Washington
+# SPDX-License-Identifier: Apache-2.0
+
+import traceback
+import logging
+from myuw.dao.persistent_messages import BannerMessage as Message
+from myuw.logger.timer import Timer
+from myuw.logger.logresp import log_api_call
+from myuw.views.api import ProtectedAPI
+from myuw.views.error import handle_exception
+
+logger = logging.getLogger(__name__)
+
+
+class BannerMessage(ProtectedAPI):
+
+    def get(self, request, *args, **kwargs):
+        """
+        GET myuw_banner_message returns 200
+        """
+        timer = Timer()
+        try:
+            data = Message(request).get_message_json()
+            log_api_call(timer, request, "Get BannerMessage")
+            return self.json_response(data)
+        except Exception:
+            return handle_exception(logger, timer, traceback)

--- a/myuw/views/page.py
+++ b/myuw/views/page.py
@@ -16,6 +16,7 @@ from myuw.dao.gws import in_myuw_test_access_group
 from myuw.dao.quicklinks import get_quicklink_data
 from myuw.dao.card_display_dates import get_card_visibilty_date_values
 from myuw.dao.messages import get_current_messages
+from myuw.dao.persistent_messages import BannerMessage as Message
 from myuw.dao.term import add_term_data_to_context
 from myuw.dao.user import get_updated_user, not_existing_user
 from myuw.dao.user_pref import get_migration_preference
@@ -94,10 +95,17 @@ def page(request,
     banner_messages = []
     for message in get_current_messages(request):
         banner_messages.append(message.message_body)
+
+    try:
+        persistent_messages = Message(request).get_message_json()
+    except Exception:
+        log_exception(logger, err, traceback)
+
     context["banner_messages"] = banner_messages
     context["display_onboard_message"] = user_pref.display_onboard_message
     context["display_pop_up"] = user_pref.display_pop_up
     context["disable_actions"] = is_action_disabled()
+    context["persistent_messages"] = persistent_messages
 
     _add_email_forwarding(request, context)
 

--- a/myuw_vue/base.js
+++ b/myuw_vue/base.js
@@ -91,6 +91,9 @@ const store = new Vuex.Store({
     bannerMessages: JSON.parse(
       document.getElementById('banner_messages').innerHTML,
     ),
+    persMessages: JSON.parse(
+      document.getElementById('persistent_messages').innerHTML,
+    ),
     displayOnboardMessage: JSON.parse(
       document.getElementById('display_onboard_message').innerHTML,
     ),

--- a/myuw_vue/components/_templates/boilerplate/banner_message.vue
+++ b/myuw_vue/components/_templates/boilerplate/banner_message.vue
@@ -1,0 +1,88 @@
+<template>
+  <div class="message px-0 py-0 myuw-text-md">
+    <div v-for="(level, l) in levels" :key="l">
+      <div :class="styleAtLevel(level)" class="list-unstyled">
+        <div v-for="(msg, i) in messageAtLevel(level)" :key="i" class="px-3 py-2">
+          <span v-html="msg.content" />
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import {} from '@fortawesome/free-solid-svg-icons';
+
+export default {
+  props: {
+    messages: {
+      type: Array,
+      required: true,
+    },
+  },
+  data: function () {
+    return {
+      levels: ['Warning', 'Info'],
+    };
+  },
+  computed: {
+    groupedMsgs() {
+      const groupedByLevel = {
+        Info: [],
+        Warning: [],
+      };
+      this.messages.forEach((msg, j) => {
+        if (msg.level_name === 'Info' || msg.level_name === 'Success') {
+          groupedByLevel['Info'].push(msg);
+        } else {
+          groupedByLevel['Warning'].push(msg);
+        }
+      });
+      return groupedByLevel;
+    },
+  },
+  methods: {
+    messageAtLevel(level) {
+      return this.groupedMsgs[level];
+    },
+    styleAtLevel(level) {
+      return level === 'Info' ? 'msg-info' : 'msg-warning';
+    },
+  },
+};
+</script>
+
+<style lang="scss" scoped>
+@use 'sass:map';
+@import '../../../../myuw/static/css/myuw/variables.scss';
+.message {
+  ::v-deep .date {
+    font-weight: bold;
+  }
+
+  ::v-deep .msg-info {
+    background-color: map.get($theme-colors, 'dark-beige');
+    color: white;
+    .external-link {
+      color: white;
+      text-decoration: underline;
+      &:hover {
+        color: map.get($theme-colors, 'beige');
+        }
+    }
+  }
+  ::v-deep .msg-warning {
+    background-color: map.get($theme-colors, 'warning') !important;
+    color: black;
+
+    .external-link {
+    text-decoration: underline;
+    color: black;
+      &:hover {
+      color: #555;
+      }
+    }
+  }
+
+}
+</style>

--- a/myuw_vue/components/_templates/boilerplate/messages.vue
+++ b/myuw_vue/components/_templates/boilerplate/messages.vue
@@ -1,19 +1,23 @@
 <template>
   <div
-    v-if="displayOnboardMessage || bannerMessages.length > 0"
-    class="w-100 myuw-messages bg-teal" role="complementary"
+    v-if="showContent"
+    class="w-100 myuw-messages" role="complementary"
   >
     <div class="text-center text-white myuw-text-md">
       <h2 class="visually-hidden">
         Announcements
       </h2>
-      <template v-if="bannerMessages.length > 0" id="message_banner_location">
+      <template v-if="bannerMessages.length || hasPersMsgToDisplay"
+        id="message_banner_location"
+      >
+        <uw-banner-message v-if="hasPersMsgToDisplay" :messages="persMessages" />
+
         <div v-for="(message, i) in bannerMessages" id="messages" :key="i"
           class="message px-3 py-2"
           v-html="message"
         ></div>
       </template>
-      <div v-if="displayOnboardMessage" class="px-3 py-2">
+      <div v-if="displayOnboardMessage" class="px-3 py-2 msg-onboard">
         New here?
         <a v-uw-modal.tourModal class="text-white"><u>See MyUW at a glance</u></a>
         <button
@@ -28,14 +32,26 @@
 </template>
 
 <script>
-import {mapState, mapMutations} from 'vuex';
+import { mapState, mapMutations} from 'vuex';
 import axios from 'axios';
+import BnrMessage from './banner_message.vue';
 export default {
+  components: {
+    'uw-banner-message': BnrMessage,
+  },
   computed: {
     ...mapState({
       bannerMessages: (state) => state.bannerMessages,
+      persMessages: (state) => state.persMessages,
       displayOnboardMessage: (state) => state.displayOnboardMessage,
     }),
+    hasPersMsgToDisplay() {
+      return this.persMessages.length > 0;
+    },
+    showContent() {
+      return (this.displayOnboardMessage || this.bannerMessages.length > 0 ||
+        this.hasPersMsgToDisplay);
+    },
   },
   methods: {
     hideOnboardMessage: function(event) {
@@ -59,6 +75,8 @@ export default {
 @use "sass:map";
 @import '../../../../myuw/static/css/myuw/variables.scss';
 
-//.myuw-messages {}
+.msg-onboard {  
+  background-color: map.get($theme-colors, 'dark-beige');
+}
 
 </style>

--- a/myuw_vue/tests/banner_message.test.js
+++ b/myuw_vue/tests/banner_message.test.js
@@ -1,0 +1,37 @@
+import { mount } from '@vue/test-utils';
+import Vuex from 'vuex';
+import { createLocalVue } from './helper';
+import BannerMessage from '../components/_templates/boilerplate/banner_message.vue';
+
+const localVue = createLocalVue(Vuex);
+const messages = [
+  {
+    "id": 2,
+    "content": "<strong>MyUW mobile app</strong> is now available! Get it at the <a href='https://apps.apple.com/us/app/myuw/id1521514519'>Apple App Store</a> and on <a href='https://play.google.com/store/apps/details?id=edu.uw.myuw_android&hl=en_US&gl=US'>Google Play</a>",
+    "level_name": "Success",
+  },
+  {
+    "id": 3,
+    "content": "Users are experiencing failed logins to UW web services, including ..., due to heavy load. Trying again often fixes the issue. See <a href='https://eoutage.uw.edu' class='external-link'>eOutage website</a> for more information.",
+    "level_name": "Warning",
+  }];
+
+describe('Banner Message Component', () => {
+  let store;
+  beforeEach(() => {
+    store = new Vuex.Store({
+      state: {},
+    });
+  });
+
+  it('Verify methods', () => {
+    const wrapper = mount(
+      BannerMessage, 
+      { store, localVue, propsData: { 'messages': messages } }
+    );
+    expect(wrapper.vm.messageAtLevel('Info').length).toBe(1);
+    expect(wrapper.vm.messageAtLevel('Warning').length).toBe(1);
+    expect(wrapper.vm.styleAtLevel('Info')).toBe("msg-info");
+    expect(wrapper.vm.styleAtLevel('Warning')).toBe("msg-warning");
+  });
+});

--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,7 @@ setup(
         'UW-RestClients-Django-Utils~=2.3',
         'Uw-Django-Oidc<1.0',
         'Django-SupportTools~=3.5',
+        'Django-Persistent-Message~=1.0',
         'Django-Safe-EmailBackend~=1.2',
         'django_client_logger<3.0',
         'UW-HX-Toolkit~=2.6',


### PR DESCRIPTION
MUWM-4885: 
* Add persistent_message on support page,
* Add the banner_message vue component
* styling persistent messages banner and onboarding banner.

Co-authored-by: Charlon Palacay <charlon@gmail.com>
Co-authored-by: William Washington <williamwashington@Williams-MacBook-Pro.local>